### PR TITLE
Refactor for fitting ricker models with constrained alpha

### DIFF
--- a/Functions/README.md
+++ b/Functions/README.md
@@ -1,18 +1,69 @@
+# Table of Contents
+
+*Documentation written with help from Claude Code*
+
+**MCMC & Sampling**
+- [`auto_tune_sampler`](#automatically-tune-the-factor-slice-sampler)
+- [`control_fssig`](#default-control-parameters-for)
+- [`control_tuning`](#default-control-parameters-for-1)
+- [`estimate_factors`](#estimate-factor-directions-from-a-burn-in-run)
+- [`factor_slice_sampler`](#run-the-factor-slice-sampler-algorithm-2-of-tibbits-et-al-2013)
+- [`fss_in_Gibbs_sample`](#factor-slice-sampler-within-a-gibbs-data-augmentation-loop)
+- [`MH_block_sample`](#metropolis-hastings-sampling-of-the-posterior-with-block-updates)
+- [`MH_Gibbs_DA`](#block-metropolis-hastings-within-gibbs-sampling-of-the-posterior-for-data-augmentation)
+- [`slice_proposals`](#draw-a-proposal-from-a-slice-interval-via-shrinkage-contraction)
+- [`step_out`](#expand-a-slice-interval-along-a-factor-direction-using-the-stepping-out-procedure)
+- [`tune_widths`](#tune-factor-slice-sampler-interval-widths)
+
+**Ricker Model — Fitting**
+- [`fit_ricker_cc`](#fit-ricker-count-model-with-complete-cases-only)
+- [`fit_ricker_DA`](#fit-a-bayesian-ricker-population-growth-model-with-potentially-missing-data)
+- [`fit_ricker_drop`](#fit-ricker-count-model-by-naively-dropping-nas)
+- [`fit_ricker_EM`](#fit-a-ricker-population-model-to-count-data-using-the-em-algorithm)
+- [`fit_ricker_MI`](#title-fit-ricker-model-to-population-count-data-with-multiple-imputation-using-amelia)
+- [`ricker_EM`](#fitting-the-ricker-population-model-to-count-data)
+
+**Ricker Model — Likelihood & Helpers**
+- [`ricker_count_nb_fit`](#fit-ricker-count-model-with-negative-binomial-errors-via-alternating-optimization)
+- [`ricker_count_neg_ll`](#negative-log-likelihood-function-for-ricker-time-series-with)
+- [`ricker_count_neg_ll_cnstr`](#constrained-negative-log-likelihood-for-a-ricker-count-time-series)
+- [`ricker_count_neg_ll_multi`](#negative-log-likelihood-for-multiple-independent-ricker-time-series)
+- [`ricker_count_pois_fit`](#fit-ricker-count-model-with-poisson-errors)
+- [`ricker_sim`](#simulate-population-abundance-from-a-stochastic-ricker-model)
+- [`ricker_step`](#one-step-in-the-deterministic-ricker-population-process)
+- [`zt_neg_binom_rng`](#draw-samples-from-a-zero-truncated-negative-binomial-distribution)
+- [`zt_poisson_rng`](#draw-samples-from-a-zero-truncated-poisson-distribution)
+
+**Gaussian (ARIMA) Fitting**
+- [`fit_arima_dropmissing`](#function-that-will-drop-missing-values-and-then-fit-model-using-arima)
+- [`fit_arima_Kalman`](#function-that-will-fit-the-model-using-arima-while-dealing-with-missing)
+- [`fit_arima_MI`](#function-that-will-fit-the-model-using-arima-while-dealing-with-missing-1)
+- [`fit_brms_model`](#fit_brms_model-use-brms-to-fit-a-missing-data-model-to-simulated-data)
+
+**Utilities**
+- [`makeMissing`](#function-that-will-introduce-varying-types-and-amounts-of-missing-data-in-a-time-series)
+- [`posterior_mode`](#compute-the-mode-of-an-empirical-distribution)
+- [`.init_theta`](#initialize-theta-from-a-list-of-y-vectors)
+- [`.make_X`](#build-a-model-matrix-x-for-a-single-complete-y-vector)
+- [`.proposal_sigma`](#compute-the-hessian-based-proposal-covariance-for-a-list-of-series)
+
+---
+
 # Automatically tune the Factor Slice Sampler
 
 ## Description
 
 Runs a three-stage auto-tuning pipeline for the Factor Slice Sampler:
 
-1. ***Width tuning (round 1):*** `[tune_widths](tune_widths)` is called
+1. ***Width tuning (round 1):*** [`tune_widths`](#tune_widths) is called
     with coordinate-aligned factor directions to find good initial interval widths.
-1. ***Factor estimation:*** `[estimate_factors](estimate_factors)` is called to
+2. ***Factor estimation:*** [`estimate_factors`](#estimate_factors) is called to
     rotate the slice directions to align with the posterior covariance structure.
-1. ***Width re-tuning (round 2):*** `[tune_widths](tune_widths)` is called
+3. ***Width re-tuning (round 2):*** [`tune_widths`](#tune_widths) is called
     again along the estimated factor directions to refine the widths.
 
 The returned `pars_afs` object can be passed directly to
-`[factor_slice_sampler](factor_slice_sampler)` for production sampling.
+[`factor_slice_sampler`](#factor_slice_sampler) for production sampling.
 
 ## Usage
 
@@ -29,17 +80,17 @@ vector as its first argument and the data list as its second.
 * `control`: Named list of tuning controls. Recognised keys (all optional):
 * `pars_afs`: Initial `pars_afs` list; `NULL` to start
     from scratch (default `NULL`).
-* `tune_w_after`: Passed to `[tune_widths](tune_widths)` (default `1`).
+* `tune_w_after`: Passed to [`tune_widths`](#tune_widths) (default `1`).
 * `ratio_target`: Target step-out ratio; passed to
-    `[tune_widths](tune_widths)` (default `0.8`).
+    [`tune_widths`](#tune_widths) (default `0.8`).
 * `stop_after`: Maximum width-tuning steps; passed to
-    `[tune_widths](tune_widths)` (default `2^10 + 1`).
+    [`tune_widths`](#tune_widths) (default `2^10 + 1`).
 * `burnin`: Burn-in iterations for factor estimation; passed to
-    `[estimate_factors](estimate_factors)` (default `500`).
+    [`estimate_factors`](#estimate_factors) (default `500`).
 
 ## Value
 
-A list with two elements (the output of the final `[tune_widths](tune_widths)`  call):
+A list with two elements (the output of the final [`tune_widths`](#tune_widths)  call):
 
 * `pars_afs`: Fully tuned parameter list with optimised `Gamma`
       (factor directions), `width` (per-factor interval widths), and
@@ -53,7 +104,7 @@ A list with two elements (the output of the final `[tune_widths](tune_widths)`  
 
 Returns a named list of default values for the factor slice sampler when used
 inside a Gibbs loop. Pass the output (or a modified copy) as the
-`control_sampler` argument of `[fss_in_Gibbs_sample](fss_in_Gibbs_sample)`.
+`control_sampler` argument of [`fss_in_Gibbs_sample`](#fss_in_gibbs_sample).
 
 ## Usage
 
@@ -68,10 +119,10 @@ A named list with the following elements:
 * `iter`: Integer. Total number of Gibbs iterations to run
       (default `1000`).
 * `time_out`: Integer. Maximum contraction attempts per factor
-      direction before `[slice_proposals](slice_proposals)` throws an error
+      direction before [`slice_proposals`](#slice_proposals) throws an error
       (default `10000`).
 * `max_steps_out`: Integer. Maximum expansion steps per direction
-      in `[step_out](step_out)` (default `10000`).
+      in [`step_out`](#step_out) (default `10000`).
 * `track_interval_steps`: Logical. Whether to record stepping-out
       and contraction counts during sampling (default `TRUE`).
 
@@ -81,7 +132,7 @@ A named list with the following elements:
 
 Returns a named list of default values for the tuning pipeline. Pass the
 output (or a modified copy) as the `control` argument of
-`[auto_tune_sampler](auto_tune_sampler)`.
+[`auto_tune_sampler`](#auto_tune_sampler).
 
 ## Usage
 
@@ -94,7 +145,7 @@ control_tuning()
 A named list with the following elements:
 
 * `pars_afs`: `NULL`; triggers initialisation from the
-      identity matrix and small random widths inside `[tune_widths](tune_widths)`.
+      identity matrix and small random widths inside [`tune_widths`](#tune_widths).
 * `tune_w_after`: Integer. Number of sampler steps between each
       width adjustment (default `1`).
 * `ratio_target`: Numeric. Target ratio of stepping-out to total
@@ -102,7 +153,7 @@ A named list with the following elements:
 * `stop_after`: Integer. Maximum width-tuning steps per round
       (default `2^10 + 1`).
 * `burnin`: Integer. Burn-in iterations used by
-      `[estimate_factors](estimate_factors)` to estimate the posterior covariance
+      [`estimate_factors`](#estimate_factors) to estimate the posterior covariance
       (default `500`).
 
 # Initialize theta from a list of y vectors
@@ -166,7 +217,7 @@ estimate_factors(theta_init, dat, lp, pars_afs, burnin = 500)
 * `lp`: Function to evaluate the log-joint probability. Must accept a parameter
 vector as its first argument and the data list as its second.
 * `pars_afs`: List of current factor slice sampler parameters. Must contain
-`Gamma` and `width`. Both are passed to `[factor_slice_sampler](factor_slice_sampler)`;
+`Gamma` and `width`. Both are passed to [`factor_slice_sampler`](#factor_slice_sampler);
 only `Gamma` and `theta_cov` are updated in the returned object.
 * `burnin`: Number of iterations to run for covariance estimation. Defaults
 to `500`.
@@ -188,7 +239,7 @@ A list with two elements:
 
 At each iteration a random slice height is drawn beneath the log-probability of
 the current point, then each factor direction is updated in turn via
-`[step_out](step_out)` (to bracket the slice) and `[slice_proposals](slice_proposals)`(to draw from within the bracket). The factor directions are taken from
+[`step_out`](#step_out) (to bracket the slice) and [`slice_proposals`](#slice_proposals)(to draw from within the bracket). The factor directions are taken from
 `pars_afs$Gamma`, so the sampler reduces to univariate slice sampling along
 the coordinate axes when `Gamma` is the identity matrix.
 
@@ -408,7 +459,7 @@ Estimates the posterior distribution of the Ricker model parameters $r$and $\alp
 a data-augmentation MCMC scheme. Starting values are obtained via empirical Bayes
 (complete-case MLE), the Factor Slice Sampler is auto-tuned on the complete cases,
 and then `chains` independent chains are run via
-`[fss_in_Gibbs_sample](fss_in_Gibbs_sample)`, which alternates between Gibbs imputation of
+[`fss_in_Gibbs_sample`](#fss_in_gibbs_sample), which alternates between Gibbs imputation of
 missing counts and factor slice updates of the parameters.
 
 ## Usage
@@ -460,16 +511,16 @@ frame with columns `yt` and `ytm1` (already in lagged-pair format,
 e.g. for a multi-patch study). If `FALSE` (default), `y` is a plain
 vector and the lagged-pair data frame is constructed internally.
 * `control_sampler`: Named list of controls passed to
-`[fss_in_Gibbs_sample](fss_in_Gibbs_sample)` via `[control_fssig](control_fssig)`. Use this
+[`fss_in_Gibbs_sample`](#fss_in_gibbs_sample) via [`control_fssig`](#control_fssig). Use this
 to override the number of sampling iterations, time-out limits, etc.
 * `control_tuner`: Named list of controls passed to
-`[auto_tune_sampler](auto_tune_sampler)` via `[control_tuning](control_tuning)`. Use this
+[`auto_tune_sampler`](#auto_tune_sampler) via [`control_tuning`](#control_tuning). Use this
 to override the width-tuning schedule, factor-estimation burn-in, etc.
 
 ## Seealso
 
-`[auto_tune_sampler](auto_tune_sampler)`, `[fss_in_Gibbs_sample](fss_in_Gibbs_sample)`,
-`[control_tuning](control_tuning)`, `[control_fssig](control_fssig)`
+[`auto_tune_sampler`](#auto_tune_sampler), [`fss_in_Gibbs_sample`](#fss_in_gibbs_sample),
+[`control_tuning`](#control_tuning), [`control_fssig`](#control_fssig)
 
 ## Value
 
@@ -504,7 +555,13 @@ spacing between observations in the time series.
 ## Usage
 
 ```r
-fit_ricker_drop(y, fam = "poisson", pro_conf = "none", off_patch = F)
+fit_ricker_drop(
+  y,
+  fam = "poisson",
+  pro_conf = "none",
+  off_patch = F,
+  patch_col = "patch"
+)
 ```
 
 ## Arguments
@@ -525,13 +582,16 @@ y <- readRDS("data/missingDatasets/pois_sim_randMiss_A.rds")[[1]]$y[[1]]
 fit_ricker_cc(y)
 ```
 
-# Wrapper to fit a Ricker count model to data using the EM algorithm
+# Fit a Ricker population model to count data using the EM algorithm
 
 ## Description
 
-This function is a wrapper to fit the stochastic Ricker model with
-either Poisson or Negative Binomial error distribution and missing observations
-encoded as NAs.
+Fits the stochastic Ricker model to a single time series of population counts,
+optionally with missing observations. Missing values are handled via Expectation
+Maximization (EM): at each E-step, missing counts are replaced by their expected
+value under the current parameter estimates; at each M-step, parameters are
+re-estimated by maximum likelihood on the filled-in series. Supports Poisson
+and Negative Binomial error distributions.
 
 ## Usage
 
@@ -541,24 +601,66 @@ fit_ricker_EM(y, fam = "poisson", off_patch = FALSE, ...)
 
 ## Arguments
 
-* `y`: Vector of population counts, with NA in the place of missing observations. If `off_patch == TRUE`,
-this should be a dataframe with `yt` and `ytm1` in separate columns, pre-filtered such
-that `ytm1` for a given time series or "patch" does not start with `NA`.
-* `fam`: Error family. Can be either c("poisson", "neg_binom").
-* `off_patch`: Logical. Set to `TRUE` when the data come from multiple replicate time series.
-* `...`: Additional arguments passed to the EM algorithm, such as initial values 
-(init_theta = c()) or maximum iterations before stopping (max_iter = 50).
+* `y`: Either (1) a numeric vector of population counts with `NA` marking
+missing observations, or (2) if `off_patch = TRUE`, a data frame with columns
+`yt` (count at time $t$) and `ytm1` (count at time $t-1$),
+already formatted into lag pairs and filtered so that no series begins with
+`ytm1 = NA`. Leading `NA`s in a vector input are stripped with a warning.
+* `fam`: Error distribution family. One of `"poisson"` (default) or
+`"neg_binom"`.
+* `off_patch`: Logical. Set to `TRUE` when `y` has already been
+formatted into lag pairs (i.e., the `yt`/`ytm1` data frame format).
+Use this when fitting to data from multiple replicate time series that have
+been row-bound into a single data frame prior to calling this function.
+Default is `FALSE`.
+* `...`: Additional arguments passed to the internal `ricker_EM` algorithm:
+* `init_theta`: Named numeric vector of starting values. For Poisson,
+    `c(r = 0.5, lalpha = log(0.01))`; for Negative Binomial, also includes
+    `lpsi = log(5)`. Note that `alpha` is parameterized on the log scale
+    internally as `lalpha = log(alpha)`, and similarly for the NB dispersion
+    parameter `psi`.
+* `tol`: Convergence tolerance on the change in negative log-likelihood
+    between successive EM iterations. Default `1e-5`.
+* `max_iter`: Maximum number of EM iterations before stopping.
+    Default `50`.
+
+## Seealso
+
+[`ricker_EM`](#ricker_em) for the underlying EM implementation,
+[`fit_ricker_DA`](#fit_ricker_da) for Bayesian estimation with posterior uncertainty,
+[`fit_ricker_cc`](#fit_ricker_cc) for complete-case (listwise deletion) MLE.
 
 ## Value
 
-List of intrinsic growth factor and intra-specific competitive effect estimates,
-standard errors, and 95EM algorithm, so `se = NA; lower = NA; upper = NA`.
+A list with the following elements:
+
+* `estim`: Named numeric vector of parameter estimates on the natural
+      scale: `r` (intrinsic growth rate) and `alpha` (intraspecific
+      competition coefficient, positive). For `fam = "neg_binom"`, also
+      includes `psi` (NB dispersion parameter).
+* `se`: Always `NA`. The EM algorithm does not directly yield
+      standard errors; use `fit_ricker_DA` for posterior uncertainty
+      quantification.
+* `lower`: Always `NA` (see `se`).
+* `upper`: Always `NA` (see `se`).
+* `convergence`: Convergence code. `0` indicates the algorithm
+      converged (NLL change fell below `tol`) before reaching `max_iter`;
+      `1` indicates the algorithm was stopped at `max_iter` without
+      converging. In the latter case a warning is issued.
+
+Returns a list with `NA` as its first element (and a named `cause` or
+`reason` element) if the series contains zeros (population extinction),
+`NaN`, `Inf`, or if the M-step optimizer fails.
 
 ## Examples
 
 ```r
 y <- readRDS("data/missingDatasets/pois_sim_randMiss_A.rds")[[1]]$y[[1]]
 fit_ricker_EM(y)
+
+# Negative Binomial with custom starting values and more iterations
+fit_ricker_EM(y, fam = "neg_binom", init_theta = c(r = 1, lalpha = log(0.05), lpsi = log(10)),
+              max_iter = 100)
 ```
 
 # Title Fit Ricker Model to population count data with Multiple Imputation using Amelia
@@ -612,12 +714,12 @@ Alternates between two steps at each iteration:
 1. ***Gibbs step:*** `fill_rng` is called to draw the missing
     observations from their full conditional distribution given the current
     parameter values $\boldsymbol\theta$.
-1. ***Factor slice step:*** `[factor_slice_sampler](factor_slice_sampler)` is called
+1. ***Factor slice step:*** [`factor_slice_sampler`](#factor_slice_sampler) is called
     for a single iteration to draw a new $\boldsymbol\theta$ given the
     just-imputed complete data.
 
 This function assumes that the factor slice sampler has already been tuned
-(via `[auto_tune_sampler](auto_tune_sampler)`) and that a valid `pars_afs` object
+(via [`auto_tune_sampler`](#auto_tune_sampler)) and that a valid `pars_afs` object
 is supplied.
 
 ## Usage
@@ -645,10 +747,10 @@ vector as its first argument and the data list as its second.
 parameter vector as its first argument and the data list as its second, and return
 an updated version of `dat$y` with all `NA`s in `yt` filled in.
 * `pars_afs`: Tuned factor slice sampler parameter list, as returned by
-`[auto_tune_sampler](auto_tune_sampler)`. Must contain `Gamma` (factor direction
+[`auto_tune_sampler`](#auto_tune_sampler). Must contain `Gamma` (factor direction
 matrix) and `width` (per-factor interval widths).
 * `control_sampler`: Named list of sampler controls. Unrecognised keys are
-ignored; missing keys fall back to `[control_fssig](control_fssig)` defaults.
+ignored; missing keys fall back to [`control_fssig`](#control_fssig) defaults.
 Recognised keys:
 * `iter`: Total number of Gibbs iterations (default `1000`).
 * `time_out`: Max contraction attempts per factor direction
@@ -796,6 +898,129 @@ posterior_mode(x)
 The mode of the empirical distribution.
 The mode of the empirical distribution.
 
+# Fit Ricker count model with negative binomial errors via alternating optimization
+
+## Description
+
+Estimates Ricker population model parameters under a negative binomial
+observation model using a two-step alternating optimization scheme.
+In step 1, the intrinsic growth rate (`r`) and log-transformed
+intra-specific competition coefficient (`lalpha`) are optimized
+conditional on the current overdispersion estimate. In step 2, the
+log-overdispersion parameter (`lpsi`) is optimized conditional on
+the current predicted means. The two steps alternate until parameter
+estimates converge or the iteration limit is reached.
+
+## Usage
+
+```r
+ricker_count_nb_fit(theta, y, tol = 1e-05, max_iter = 500)
+```
+
+## Arguments
+
+* `theta`: Named numeric vector of initial parameter values. Must contain
+elements named `"r"` (intrinsic growth rate), `"lalpha"`
+(log of the intra-specific competition coefficient), and `"lpsi"`
+(log of the negative binomial overdispersion parameter).
+* `y`: Either a numeric vector of population counts through time, or a
+data frame with columns `yt` (count at time $t$) and
+`ytm1` (count at time $t-1$). If a vector is supplied it is
+automatically converted to the lagged data frame format.
+* `tol`: Numeric scalar. Convergence tolerance; the Euclidean distance
+between successive parameter vectors must fall below this value for the
+algorithm to be considered converged. Defaults to `1e-5`.
+* `max_iter`: Integer. Maximum number of alternating-optimization
+iterations before the algorithm stops regardless of convergence.
+Defaults to `500`.
+
+## Details
+
+The Ricker mean function is $\mu_t = y_{t-1} \exp(r - \alpha y_{t-1})$,
+where $\alpha$ is constrained to be positive via the log
+parameterization `lalpha = log(alpha)`.
+
+## Value
+
+A named list with the following elements:
+
+* `estim`: Named numeric vector of point estimates for
+      `r`, `alpha` (back-transformed from `lalpha`), and
+      `psi` (back-transformed from `lpsi`).
+* `se`: Named numeric vector of standard errors for `r`
+      and `alpha`. The SE for `alpha` is obtained via the delta
+      method. `psi` SE is `NA` as it is estimated via
+      `optimize()` without a Hessian.
+* `lower`: Numeric vector of lower 95% confidence limits for
+      `r` and `alpha`. `psi` lower limit is `NA`.
+* `upper`: Numeric vector of upper 95% confidence limits for
+      `r` and `alpha`. `psi` upper limit is `NA`.
+* `convergence`: Integer flag: `0` if the algorithm
+      converged within `max_iter` iterations, `1` otherwise.
+
+## Examples
+
+```r
+y <- readRDS("data/missingDatasets/nb_sim_randMiss_A.rds")[[1]]$y[[1]]
+init <- c(r = 1, lalpha = log(0.01), lpsi = log(5))
+ricker_count_nb_fit(theta = init, y = y)
+```
+
+# Constrained negative log-likelihood for a Ricker count time series
+
+## Description
+
+Computes the negative log-likelihood of a Ricker population model with
+Poisson or Negative Binomial observations, where the density-dependence
+parameter $\alpha$ is log-parameterized to enforce positivity. The
+log-linear mean at time $t$ is:
+$$\log \mu_t = \log N_{t-1} + r - \alpha N_{t-1}$$where $\alpha = \exp(\texttt{lalpha}) > 0$, ensuring negative density
+dependence. This is the likelihood used by fitting routines that optimize
+over a constrained parameter space.
+
+## Usage
+
+```r
+ricker_count_neg_ll_cnstr(theta, y, X = NULL, fam = "poisson")
+```
+
+## Arguments
+
+* `theta`: Named numeric vector of parameters. Must contain:
+* `r`: Intrinsic growth rate (unconstrained, real-valued).
+* `lalpha`: Log of the intraspecific competition coefficient.
+    Exponentiated internally so that $\alpha = e^{\texttt{lalpha}} > 0$.
+* `lpsi`: Log of the Negative Binomial dispersion parameter
+    ($\psi = e^{\texttt{lpsi}} > 0$). Required when `fam = "neg_binom"`;
+    ignored otherwise.
+* `y`: Observed count data. Accepted formats:
+* Numeric vector: Raw time series. Lag pairs `(yt, ytm1)` are
+    constructed internally.
+* Data frame or matrix: Must have named columns `yt` (count at
+    time $t$) and `ytm1` (count at time $t-1$), i.e., the
+    offset/lag-pair format used elsewhere in this package. Rows may come
+    from multiple concatenated series when using `off_patch` mode.`NA`s should be filled in before calling this function.
+* `X`: Ignored. Retained for interface compatibility with
+[`ricker_count_neg_ll`](#ricker_count_neg_ll). Lag pairs are always derived from `y`.
+* `fam`: Error distribution family. One of `"poisson"` (default) or
+`"neg_binom"`.
+
+## Details
+
+Unlike [`ricker_count_neg_ll`](#ricker_count_neg_ll), this function accepts `y`in several formats and constructs the lag pairs internally, so no separate
+model matrix needs to be supplied.
+
+## Seealso
+
+[`ricker_count_neg_ll`](#ricker_count_neg_ll) for the unconstrained version,
+[`ricker_step`](#ricker_step) for the deterministic Ricker step,
+[`fit_ricker_cc`](#fit_ricker_cc) and [`fit_ricker_EM`](#fit_ricker_em) which use
+  this function internally.
+
+## Value
+
+Scalar negative log-likelihood evaluated at `theta`.
+
 # Negative log-likelihood for multiple independent Ricker time series
 
 ## Description
@@ -856,6 +1081,65 @@ should be y. Additional covariates can be added.
 Scalar value of the negative log likelihood of `theta` given the data
 Scalar value of the negative log likelihood of `theta` given the data
 
+# Fit Ricker count model with Poisson errors
+
+## Description
+
+Estimates Ricker population model parameters under a Poisson observation
+model via a single call to `optim`. The intra-specific competition
+coefficient $\alpha$ is constrained to be positive through the log
+parameterization `lalpha = log(alpha)`.
+
+## Usage
+
+```r
+ricker_count_pois_fit(theta_init, y)
+```
+
+## Arguments
+
+* `theta_init`: Named numeric vector of initial parameter values. Must
+contain elements named `"r"` (intrinsic growth rate) and
+`"lalpha"` (log of the intra-specific competition coefficient).
+* `y`: Either a numeric vector of population counts through time, or a
+data frame with columns `yt` (count at time $t$) and
+`ytm1` (count at time $t-1$). If a vector is supplied it is
+converted internally to the lagged data frame format.
+
+## Details
+
+The Ricker mean function is $\mu_t = y_{t-1} \exp(r - \alpha y_{t-1})$,
+where counts at time $t$ are assumed to follow a Poisson distribution
+with mean $\mu_t$.
+
+## Value
+
+A named list with the following elements:
+
+* `estim`: Named numeric vector of point estimates for
+      `r` and `alpha` (back-transformed from `lalpha`).
+* `se`: Named numeric vector of standard errors. The SE for
+      `alpha` is obtained via the delta method.
+* `lower`: Numeric vector of lower 95% confidence limits for
+      `r` and `alpha`.
+* `upper`: Numeric vector of upper 95% confidence limits for
+      `r` and `alpha`.
+* `working`: Named numeric vector of estimates on the working
+      (log) scale, i.e. `r` and `lalpha`.
+* `V`: Variance-covariance matrix of the working-scale
+      estimates, derived from the inverse Hessian returned by
+      `optim`.
+* `convergence`: Integer convergence flag from `optim`:
+      `0` indicates successful convergence.
+
+## Examples
+
+```r
+y <- readRDS("data/missingDatasets/pois_sim_randMiss_A.rds")[[1]]$y[[1]]
+init <- c(r = 1, lalpha = log(0.01))
+ricker_count_pois_fit(theta_init = init, y = y)
+```
+
 # Fitting the Ricker population model to count data
 
 ## Description
@@ -866,14 +1150,7 @@ with Poisson or Negative-Binomial demographic stochasticity.
 ## Usage
 
 ```r
-ricker_EM(
-  y,
-  init_theta,
-  fam = "poisson",
-  tol = 1e-05,
-  max_iter = 50,
-  off_patch = FALSE
-)
+ricker_EM(y, init_theta, fam = "poisson", tol = 1e-05, max_iter = 50)
 ```
 
 ## Arguments
@@ -1034,6 +1311,7 @@ tune_widths(
   dat,
   lp,
   pars_afs = NULL,
+  init_width = 0.1,
   tune_w_after = 1,
   ratio_target = 0.8,
   stop_after = 2^10 + 1
@@ -1065,4 +1343,73 @@ A list with two elements:
 * `pars_afs`: Updated parameter list with tuned `width` values.
 * `theta`: Named numeric vector of the last sampled parameter values,
       suitable for use as `theta_init` in a subsequent run.
+
+# Draw samples from a zero-truncated Negative Binomial distribution
+
+## Description
+
+Generates random draws from a Negative Binomial distribution conditioned on
+the outcome being strictly positive ($X \geq 1$). Uses the same
+inverse-CDF method as [`zt_poisson_rng`](#zt_poisson_rng): a uniform variate is
+drawn on $[p_0, 1]$, where $p_0 = P(X = 0)$ under the untruncated
+Negative Binomial, and then mapped through the NB quantile function.
+Used during data augmentation to impute missing counts under Negative
+Binomial error while avoiding zeros in the likelihood.
+
+## Usage
+
+```r
+zt_neg_binom_rng(n, mu, size)
+```
+
+## Arguments
+
+* `n`: Number of draws to return.
+* `mu`: Mean of the underlying (untruncated) Negative Binomial distribution.
+Must be positive. Corresponds to the `mu` parameterization in
+[`dnbinom`](https://rdrr.io/r/stats/NegBinomial.html).
+* `size`: Dispersion (size) parameter of the Negative Binomial distribution
+($\psi$ elsewhere in this package). Must be positive. Larger values
+approach the Poisson limit.
+
+## Seealso
+
+[`zt_poisson_rng`](#zt_poisson_rng) for the Poisson analogue,
+[`dnbinom`](https://rdrr.io/r/stats/NegBinomial.html) for the parameterization used.
+
+## Value
+
+Integer vector of length `n` with all elements $\geq 1$.
+
+# Draw samples from a zero-truncated Poisson distribution
+
+## Description
+
+Generates random draws from a Poisson distribution conditioned on the outcome
+being strictly positive ($X \geq 1$). Uses the inverse-CDF method: a
+uniform variate is drawn on $[p_0, 1]$, where $p_0 = P(X = 0)$ under
+the untruncated Poisson, and then mapped through the Poisson quantile function.
+This guarantees all returned values are $\geq 1$ without rejection sampling.
+Used during data augmentation to impute missing counts while avoiding zeros
+that would cause $\log(0)$ in the likelihood.
+
+## Usage
+
+```r
+zt_poisson_rng(n, lambda)
+```
+
+## Arguments
+
+* `n`: Number of draws to return.
+* `lambda`: Rate parameter of the underlying (untruncated) Poisson distribution.
+Must be positive.
+
+## Seealso
+
+[`zt_neg_binom_rng`](#zt_neg_binom_rng) for the Negative Binomial analogue.
+
+## Value
+
+Integer vector of length `n` with all elements $\geq 1$.
 

--- a/Functions/ricker_count_EM.R
+++ b/Functions/ricker_count_EM.R
@@ -1,8 +1,8 @@
-####################################################
+####################################################-
 # This is a user-defined function to fit Ricker
 # population models to count data, potentially with 
 # missing observations, using EM
-####################################################
+####################################################-
 
 source(here::here("Functions/ricker_count_likelihood_functions.R"))
 #' Fitting the Ricker population model to count data
@@ -21,26 +21,19 @@ source(here::here("Functions/ricker_count_likelihood_functions.R"))
 #' full data vector with latent values filled in (\code{z_hat}), and a convergence code. 0 means 
 #' the algorithm converged before being stopped.
 #' 
-ricker_EM <- function(y, init_theta, fam = "poisson", tol = 1e-5, max_iter = 50, off_patch = FALSE){
+ricker_EM <- function(y, init_theta, fam = "poisson", tol = 1e-5, max_iter = 50){
   
-  if(off_patch){
-    n <- nrow(y) + 1
-  } else{
-    n <- length(y)
-    # remove starting NAs
-    if(is.na(y[1])){
-      obs <- which(!is.na(y))
-      y <- y[min(obs):n]
-      n <- length(y)
-    }
+  if(!all(c("yt", "ytm1") %in% colnames(y))){
+    stop("Expecting y as a dataframe or matrix with yt and ytm1 as named columns.")
   }
   p <- length(init_theta)
   
   # define initial parameter vector
   Theta <- matrix(init_theta, ncol = length(init_theta), nrow= 1)
+  colnames(Theta) <- names(init_theta)
   
   # define matrix of latent vectors
-  Z <- matrix(data = NA, ncol = n, nrow = 1)
+  Z <- matrix(data = NA, ncol = nrow(y), nrow = 1)
   
   nll <- vector(mode = "double")
   
@@ -53,60 +46,39 @@ ricker_EM <- function(y, init_theta, fam = "poisson", tol = 1e-5, max_iter = 50,
     #initialize latent data
     z_s <- y
     
-    # determine parameter sets
-    theta <- as.double(Theta[s, ])
-    if(fam == "poisson"){
-      beta <- theta
-    }
+    theta_curr <- Theta[s, ]
     if(fam == "neg_binom"){
-      beta <- theta[-p]
-      phi <- theta[p]
+      beta_curr <- theta_curr[1:2]
+    } else {
+      beta_curr <- theta_curr
     }
+    beta_curr[2] <- exp(beta_curr[2])
+    
     
     # fill in missing values with their expected values
-    # first the single vector option
-    if(isFALSE(off_patch)){
-      for(t in 2:n){
-        if(is.na(z_s[t])){
-          z_s[t] <- round(ricker_step(beta, z_s[t - 1]))
-          # if rounds to zero, round up instead
-          if(z_s[t] == 0){z_s[t] <- 1}
+    for(t in 1:nrow(z_s)){
+      if(is.na(z_s[t, "yt"])){
+        z_s[t, "yt"] <- round(ricker_step(beta_curr, z_s[t, "ytm1"]))
+        if(z_s[t, "yt"] == 0){
+          z_s[t, "yt"] <- 1
         }
-      }
-      X <- cbind(
-        rep(1, n),
-        z_s
-      )
-    }
-    
-    if(off_patch) {
-      for(t in 1:nrow(z_s)){
-        if(is.na(z_s[t, "yt"])){
-          z_s[t, "yt"] <- round(ricker_step(beta, z_s[t, "ytm1"]))
-          if(t < nrow(z_s)){
+        if(t < nrow(z_s)){
+          if(is.na(z_s[t + 1, "ytm1"])){
             z_s[t + 1, "ytm1"] <- z_s[t, "yt"]
           }
         }
       }
-      # round up if rounding to zero
-      z_s[z_s == 0] <- 1
-      
-      # undo the offsetting for use with ricker_count_neg_ll
-      z_s_vec <- c(z_s[1, "ytm1"], z_s[, "yt"])
-      X <- cbind(
-        rep(1, n),
-        z_s_vec
-      )
-      # overwrite for later steps
-      z_s <- z_s_vec
     }
 
     # adding try catch here to avoid error "function cannot be evaluated at initial parameters"
     fit_s <- tryCatch({
-      optim(
-        par = theta, fn = ricker_count_neg_ll,
-        y = z_s, X = X, fam = fam, hessian = T
-      )
+      if(fam == "poisson"){
+        ricker_count_pois_fit(theta_curr, z_s)
+      } else if(fam == "neg_binom"){
+        ricker_count_nb_fit(theta_curr, z_s)
+      } else {
+        stop("fam must be poisson or neg_binom")
+      }
     },error=function(cond){
       message(paste("we have had an error in evaluating function at initial parameters"))
       return(NA)
@@ -118,14 +90,14 @@ ricker_EM <- function(y, init_theta, fam = "poisson", tol = 1e-5, max_iter = 50,
     # store new value of theta and update
     Theta <- rbind(
       Theta,
-      fit_s$par
+      fit_s$working
     )
     Z <- rbind(
-      Z, z_s
+      Z, z_s[["yt"]]
     )
-    nll <- c(nll, fit_s$value)
+    nll <- c(nll, fit_s$nll)
     
-    # calculate the mean relative difference
+    # calculate the difference
     if(s == 1){
       dif <- dif
     } else{
@@ -139,14 +111,21 @@ ricker_EM <- function(y, init_theta, fam = "poisson", tol = 1e-5, max_iter = 50,
   }
   
   # compute final values for the return list
-  theta_star <- as.double(Theta[nrow(Theta), ])
+  theta_star <- Theta[nrow(Theta), ]
+  theta_star["lalpha"] <- exp(theta_star["lalpha"])
+  names(theta_star)[which(names(theta_star) == "lalpha")] <- "alpha"
+  if(fam == "neg_binom"){
+    theta_star["lpsi"] <- exp(theta_star["lpsi"])
+    names(theta_star)[which(names(theta_star) == "lpsi")] <- "psi"
+  }
   convergence <- as.numeric(s == max_iter)
   
   return(list(
     theta = theta_star,
     Theta = Theta,
     z_s = z_s,
-    convergence = convergence
+    convergence = convergence,
+    nll = nll[length(nll)]
   ))
   
 }
@@ -184,7 +163,7 @@ fit_ricker_EM <- function(y, fam = "poisson", off_patch = FALSE, ...){
     if(!all(c("yt", "ytm1") %in% colnames(y))){
       stop("If feeding in offset data, ensure that yt and ytm1 are named columns.")
     }
-    y <- as.matrix(y[,c("ytm1", "yt")])
+    y <- as.matrix(y[,c("yt", "ytm1")])
   }
   # Check for population extinction
   if(sum(y==0,na.rm=T)>1){
@@ -214,16 +193,24 @@ fit_ricker_EM <- function(y, fam = "poisson", off_patch = FALSE, ...){
   }
   
   # remove starting NAs
-  if(is.na(y[1])){
-    warning("Removing starting NAs...")
-    start <- min(which(!is.na(y)))
-    y <- y[start:length(y)]
+  if(is.vector(y)){
+    if(is.na(y[1])){
+      warning("Removing starting NAs...")
+      start <- min(which(!is.na(y)))
+      y <- y[start:length(y)]
+    }
+    dat <- data.frame(
+      yt = y[2:length(y)],
+      ytm1 = y[1:(length(y) - 1)]
+    )
+  } else {
+    dat <- y[, c("yt", "ytm1")]
   }
   
   if(!exists("init_theta", args)){
-    init_theta <- c(0.5, -0.01)
+    init_theta <- c(r = 0.5, lalpha = log(0.01))
     if(fam == "neg_binom"){
-      init_theta <- c(init_theta, 5)
+      init_theta <- c(init_theta, lpsi = log(5))
     }
     args$init_theta <- init_theta
   }
@@ -232,9 +219,8 @@ fit_ricker_EM <- function(y, fam = "poisson", off_patch = FALSE, ...){
   
   args <- c(
     list(
-      y = y,
-      fam = fam,
-      off_patch = off_patch
+      y = dat,
+      fam = fam
     ),
     args
   )
@@ -246,26 +232,16 @@ fit_ricker_EM <- function(y, fam = "poisson", off_patch = FALSE, ...){
     return(list(NA,reason="we have had an error in evaluating function at initial parameters"))
   }
   
-  if(fam == "neg_binom"){
-    parnames <- c("r", "alpha", "psi")
-    estims <- fit$theta * c(1, -1, 1)
-    names(estims) <- parnames
-  }
-  if(fam == "poisson"){
-    parnames <- c("r", "alpha")
-    estims <- fit$theta * c(1, -1)
-    names(estims) <- parnames
-  }
-  
   if(fit$convergence == 1){
     warning("EM algorithm did not converge. Consider different starting values or increasing max_iter.")
   }
   
   return(list(
-    estim = estims,
+    estim = fit$theta,
     se = NA,
     lower = NA,
-    upper = NA
+    upper = NA,
+    convergence = fit$convergence
   ))
   
 }

--- a/Functions/ricker_count_EM.R
+++ b/Functions/ricker_count_EM.R
@@ -24,7 +24,7 @@ source(here::here("Functions/ricker_count_likelihood_functions.R"))
 ricker_EM <- function(y, init_theta, fam = "poisson", tol = 1e-5, max_iter = 50){
   
   if(!all(c("yt", "ytm1") %in% colnames(y))){
-    stop("Expecting y as a dataframe or matrix with yt and ytm1 as named columns.")
+    stop("Expecting y as a dataframe with yt and ytm1 as named columns.")
   }
   p <- length(init_theta)
   
@@ -132,29 +132,72 @@ ricker_EM <- function(y, init_theta, fam = "poisson", tol = 1e-5, max_iter = 50)
 
 
 
-#' Wrapper to fit a Ricker count model to data using the EM algorithm
-#' 
-#' This function is a wrapper to fit the stochastic Ricker model with
-#' either Poisson or Negative Binomial error distribution and missing observations
-#' encoded as NAs.
+#' Fit a Ricker population model to count data using the EM algorithm
 #'
-#' @param y Vector of population counts, with NA in the place of missing observations. If \code{off_patch == TRUE},
-#' this should be a dataframe with \code{yt} and \code{ytm1} in separate columns, pre-filtered such
-#' that \code{ytm1} for a given time series or "patch" does not start with \code{NA}.
-#' @param fam Error family. Can be either c("poisson", "neg_binom").
-#' @param off_patch Logical. Set to \code{TRUE} when the data come from multiple replicate time series.
-#' @param ... Additional arguments passed to the EM algorithm, such as initial values 
-#' (init_theta = c()) or maximum iterations before stopping (max_iter = 50).
+#' Fits the stochastic Ricker model to a single time series of population counts,
+#' optionally with missing observations. Missing values are handled via Expectation
+#' Maximization (EM): at each E-step, missing counts are replaced by their expected
+#' value under the current parameter estimates; at each M-step, parameters are
+#' re-estimated by maximum likelihood on the filled-in series. Supports Poisson
+#' and Negative Binomial error distributions.
 #'
-#' @return List of intrinsic growth factor and intra-specific competitive effect estimates,
-#' standard errors, and 95% confidence limits. The standard errors are not available using the
-#' EM algorithm, so \code{se = NA; lower = NA; upper = NA}. 
+#' @param y Either (1) a numeric vector of population counts with \code{NA} marking
+#'   missing observations, or (2) if \code{off_patch = TRUE}, a data frame with columns
+#'   \code{yt} (count at time \eqn{t}) and \code{ytm1} (count at time \eqn{t-1}),
+#'   already formatted into lag pairs and filtered so that no series begins with
+#'   \code{ytm1 = NA}. Leading \code{NA}s in a vector input are stripped with a warning.
+#' @param fam Error distribution family. One of \code{"poisson"} (default) or
+#'   \code{"neg_binom"}.
+#' @param off_patch Logical. Set to \code{TRUE} when \code{y} has already been
+#'   formatted into lag pairs (i.e., the \code{yt}/\code{ytm1} data frame format).
+#'   Use this when fitting to data from multiple replicate time series that have
+#'   been row-bound into a single data frame prior to calling this function.
+#'   Default is \code{FALSE}.
+#' @param ... Additional arguments passed to the internal \code{ricker_EM} algorithm:
+#'   \describe{
+#'     \item{\code{init_theta}}{Named numeric vector of starting values. For Poisson,
+#'       \code{c(r = 0.5, lalpha = log(0.01))}; for Negative Binomial, also includes
+#'       \code{lpsi = log(5)}. Note that \code{alpha} is parameterized on the log scale
+#'       internally as \code{lalpha = log(alpha)}, and similarly for the NB dispersion
+#'       parameter \code{psi}.}
+#'     \item{\code{tol}}{Convergence tolerance on the change in negative log-likelihood
+#'       between successive EM iterations. Default \code{1e-5}.}
+#'     \item{\code{max_iter}}{Maximum number of EM iterations before stopping.
+#'       Default \code{50}.}
+#'   }
+#'
+#' @return A list with the following elements:
+#'   \describe{
+#'     \item{\code{estim}}{Named numeric vector of parameter estimates on the natural
+#'       scale: \code{r} (intrinsic growth rate) and \code{alpha} (intraspecific
+#'       competition coefficient, positive). For \code{fam = "neg_binom"}, also
+#'       includes \code{psi} (NB dispersion parameter).}
+#'     \item{\code{se}}{Always \code{NA}. The EM algorithm does not directly yield
+#'       standard errors; use \code{fit_ricker_DA} for posterior uncertainty
+#'       quantification.}
+#'     \item{\code{lower}}{Always \code{NA} (see \code{se}).}
+#'     \item{\code{upper}}{Always \code{NA} (see \code{se}).}
+#'     \item{\code{convergence}}{Convergence code. \code{0} indicates the algorithm
+#'       converged (NLL change fell below \code{tol}) before reaching \code{max_iter};
+#'       \code{1} indicates the algorithm was stopped at \code{max_iter} without
+#'       converging. In the latter case a warning is issued.}
+#'   }
+#'   Returns a list with \code{NA} as its first element (and a named \code{cause} or
+#'   \code{reason} element) if the series contains zeros (population extinction),
+#'   \code{NaN}, \code{Inf}, or if the M-step optimizer fails.
+#'
+#' @seealso \code{\link{ricker_EM}} for the underlying EM implementation,
+#'   \code{\link{fit_ricker_DA}} for Bayesian estimation with posterior uncertainty,
+#'   \code{\link{fit_ricker_cc}} for complete-case (listwise deletion) MLE.
 #'
 #' @examples
-#' 
 #' y <- readRDS("data/missingDatasets/pois_sim_randMiss_A.rds")[[1]]$y[[1]]
 #' fit_ricker_EM(y)
-#' 
+#'
+#' # Negative Binomial with custom starting values and more iterations
+#' fit_ricker_EM(y, fam = "neg_binom", init_theta = c(r = 1, lalpha = log(0.05), lpsi = log(10)),
+#'               max_iter = 100)
+#'
 fit_ricker_EM <- function(y, fam = "poisson", off_patch = FALSE, ...){
   
   args <- list(...)
@@ -204,7 +247,7 @@ fit_ricker_EM <- function(y, fam = "poisson", off_patch = FALSE, ...){
       ytm1 = y[1:(length(y) - 1)]
     )
   } else {
-    dat <- y[, c("yt", "ytm1")]
+    dat <- as.data.frame(y[, c("yt", "ytm1")])
   }
   
   if(!exists("init_theta", args)){

--- a/Functions/ricker_count_MCMC.R
+++ b/Functions/ricker_count_MCMC.R
@@ -276,11 +276,20 @@ step_out <- function(k, theta_curr, pars_afs, h, lp, dat, max_steps_out = 10000)
   x_high <- x_low + width
   Gam_k <- pars_afs$Gamma[, k]
   
+  # safe_lp <- function(x) {
+  #   val <- lp(x, dat)
+  #   if (!is.finite(val)) {
+  #     warning(sprintf("step_out: lp returned %s at factor %d — treating as -Inf", val, k))
+  #     return(-Inf)
+  #   }
+  #   val
+  # }
+  
   # do the lower bound
   h_low <- lp(x_low * Gam_k + theta_curr, dat)
   i <- 0
   n_expand <- 0
-  while (i < max_steps_out & h_low > h) {
+  while (i < max_steps_out & isTRUE(h_low > h)) {
     x_low <- x_low - width
     h_low <- lp(x_low * Gam_k + theta_curr, dat)
     i <- i + 1
@@ -291,7 +300,7 @@ step_out <- function(k, theta_curr, pars_afs, h, lp, dat, max_steps_out = 10000)
   # now expand upper bound
   h_high <- lp(x_high * Gam_k + theta_curr, dat)
   i <- 0
-  while(i < max_steps_out & h_high > h) {
+  while(i < max_steps_out & isTRUE(h_high > h)) {
     x_high <- x_high + width
     h_high <- lp(x_high * Gam_k + theta_curr, dat)
     i <- i + 1
@@ -1284,6 +1293,10 @@ fit_ricker_DA <- function(
       lprob <- lprob +
         dnorm(theta["lpsi"], mean = datlist$m_lpsi, sd = datlist$sd_lpsi, log = T)
     }
+    # defend against infinite or NaN
+    if(!is.finite(lprob) | is.nan(lprob) | is.na(lprob)){
+      return(-Inf)
+    }
     return(unname(lprob))
   }
   
@@ -1293,16 +1306,25 @@ fit_ricker_DA <- function(
     for(t in 1:nrow(y)){
       if(is.na(y[t, "yt"])){
         mu_t <- ricker_step(
-          theta = c(theta["r"], -exp(theta["lalpha"])), 
+          theta = c(theta["r"], exp(theta["lalpha"])), 
           Nt = y[t, "ytm1"]
         )
+        # fallback
+        if(!is.finite(mu_t)){
+          warning("computed non finite mu_t. Falling back to y_tm1")
+          mu_t <- y[t, "ytm1"]
+        }
         if(datlist$fam == "poisson"){
           y[t, "yt"] <- zt_poisson_rng(1, mu_t)
-          y[t + 1, "ytm1"] <- y[t, "yt"]
+          if(is.na(y[t + 1, "ytm1"])){
+            y[t + 1, "ytm1"] <- y[t, "yt"]
+          }
         }
         if(datlist$fam == "neg_binom"){
           y[t, "yt"] <- zt_neg_binom_rng(1, size = exp(theta["lpsi"]), mu = mu_t)
-          y[t + 1, "ytm1"] <- y[t, "yt"]
+          if(is.na(y[t + 1, "ytm1"])){
+            y[t + 1, "ytm1"] <- y[t, "yt"]
+          }
         }
       }
     }

--- a/Functions/ricker_count_likelihood_functions.R
+++ b/Functions/ricker_count_likelihood_functions.R
@@ -65,6 +65,57 @@ ricker_count_neg_ll <- function(theta, y, X = NULL, fam = "poisson"){
 }
 
 
+
+ricker_count_neg_ll_cnstr <- function(theta, y, X = NULL, fam = "poisson"){
+  
+  if(is.vector(y)){
+    X <- data.frame(
+      yt = y[2:length(y)],
+      ytm1 = y[1:(length(y) - 1)]
+    )
+  } else if(is.data.frame(y)){
+    if(!all(c("yt", "ytm1") %in% names(y))){
+      stop("Expecting an offset dataframe with columns yt and ytm1")
+    }
+    X <- y[, c("yt", "ytm1")]
+  } else {
+    stop("y must be a vector or an offset dataframe with columns yt and ytm1")
+  }
+  
+  n <- nrow(X) + 1
+  p <- length(theta)
+  
+  # constrained alpha
+  alpha <- exp(theta["lalpha"])
+  
+  # compute means
+  eta <- vector(mode = "double", length = n)
+  eta[1] <- log(X[1, "ytm1"])
+
+  # compute means
+  for(t in 1:(n - 1)){
+    eta[t + 1] <- log(X[t, "ytm1"]) + theta["r"] - alpha * X[t, "ytm1"]
+  }
+  
+  if(fam == "poisson"){
+    
+    # return the negative log-likelihood
+    return(-sum(
+      dpois(x = X[1:(n - 1), "yt"], lambda = exp(eta[2:n]), log = T)
+    ))
+  }
+  if(fam == "neg_binom"){
+    psi <- exp(theta["lpsi"])
+
+    # return the negative log-likelihood
+    return(-sum(
+      dnbinom(x = X[1:(n - 1), "yt"], mu = exp(eta[2:n]), size = psi, log = T)
+    ))
+  }
+  
+}
+
+
 zt_poisson_rng <- function(n, lambda){
 
   p0 <- dpois(0, lambda = lambda)
@@ -96,6 +147,122 @@ ricker_count_neg_ll_multi <- function(theta, y_list, X_list, fam = "poisson"){
     total_nll <- total_nll + ricker_count_neg_ll(theta, y_list[[i]], X_list[[i]], fam)
   }
   return(total_nll)
+}
+
+
+ricker_count_nb_fit <- function(theta, y, tol = 1e-5, max_iter = 500){
+  
+  if(is.vector(y)){
+    X <- data.frame(
+      yt = y[2:length(y)],
+      ytm1 = y[1:(length(y) - 1)]
+    )
+  } else if(is.data.frame(y)){
+    if(!all(c("yt", "ytm1") %in% names(y))){
+      stop("Expecting an offset dataframe with columns yt and ytm1")
+    }
+    X <- y[, c("yt", "ytm1")]
+  } else {
+    stop("y must be a vector or an offset dataframe with columns yt and ytm1")
+  }
+  
+  # ---- Objective functions ----
+  ## ---- Step 1 ----
+  step_1_obj_fun <- function(theta, X, psi){
+    n <- nrow(X) + 1
+    p <- length(theta)
+    
+    # constrained alpha
+    alpha <- exp(theta["lalpha"])
+    
+    # compute means
+    eta <- vector(mode = "double", length = n)
+    eta[1] <- log(X[1, "ytm1"])
+    
+    # compute means
+    for(t in 1:(n - 1)){
+      eta[t + 1] <- log(X[t, "ytm1"]) + theta["r"] - alpha * X[t, "ytm1"]
+    }
+    
+    # return the negative log-likelihood
+    return(-sum(
+      dnbinom(x = X[1:(n - 1), "yt"], mu = exp(eta[2:n]), size = psi, log = T)
+    ))
+  }
+  
+  ## ---- Step 2 ----
+  step_2_obj_fun <- function(lpsi, X, mu){
+    # return the negative log-likelihood
+    return(-sum(
+      dnbinom(x = X[1:(n - 1), "yt"], mu = mu, size = exp(lpsi), log = T)
+    ))
+  }
+  
+  # ---- Main loop ----
+  theta_curr <- theta[c("r", "lalpha")]
+  lpsi_curr <- theta["lpsi"]
+  H <- matrix(nrow = length(theta_curr), ncol = length(theta_curr))
+  i <- 0
+  diff <- 999
+  while(diff > tol & i < max_iter){
+    
+    # optimize r and lalpha
+    fit_i1 <- optim(theta_curr, step_1_obj_fun, X = X, psi = exp(lpsi_curr), hessian = T)
+    
+    theta_prop <- fit_i1$par
+    H <- fit_i1$hessian
+    
+    # now get mu for the current values
+    eta <- vector(mode = "double", length = n)
+    eta[1] <- log(X[1, "ytm1"])
+    
+    # compute means
+    for(t in 1:(n - 1)){
+      eta[t + 1] <- log(X[t, "ytm1"]) + theta_prop["r"] - exp(theta_prop["lalpha"]) * X[t, "ytm1"]
+    }
+    
+    fit_i2 <- optimize(step_2_obj_fun, interval = c(0, log(50)), X = X, mu = exp(eta))
+    
+    lpsi_prop <- fit_i2$minimum
+    
+    diff <- sqrt(sum(
+      (c(theta_curr, lpsi_curr) - c(theta_prop, lpsi_prop))^2
+    ))
+    i <- i + 1
+    theta_curr <- theta_prop
+    lpsi_curr <- lpsi_prop
+    
+  }
+  
+  # ---- compiling return objects ----
+  estims <- theta_curr
+  estims["lalpha"] <- exp(estims["lalpha"])
+  names(estims)[2] <- "alpha"
+  
+  # CIs and SEs
+  V <- solve(H)
+  ses <- sqrt(diag(V))
+  cis <- mapply(FUN = function(x, s){ x + c(-1, 1) * 2 * s }, x = theta_curr, s = ses)
+  # convert lalpha
+  cis[, 2] <- exp(cis[, 2])
+  cis <- t(cis)
+  colnames(cis) <- c("lower_95", "upper_95")
+  
+  # need to use the delta method for se of alpha
+  ses[2] <- sqrt(sqrt(ses[2]) * exp(theta_curr[2])^2)
+  names(ses) <- names(estims)
+  
+  return(
+    list(
+      estim = estims,
+      se = ses,
+      lower = as.double(cis[, 1]),
+      upper = as.double(cis[, 2]),
+      convergence = ifelse(i < max_iter, 0, 1),
+      psi = exp(lpsi_curr)
+    )
+  )
+  
 }
 
 

--- a/Functions/ricker_count_likelihood_functions.R
+++ b/Functions/ricker_count_likelihood_functions.R
@@ -66,6 +66,52 @@ ricker_count_neg_ll <- function(theta, y, X = NULL, fam = "poisson"){
 
 
 
+#' Constrained negative log-likelihood for a Ricker count time series
+#'
+#' Computes the negative log-likelihood of a Ricker population model with
+#' Poisson or Negative Binomial observations, where the density-dependence
+#' parameter \eqn{\alpha} is log-parameterized to enforce positivity. The
+#' log-linear mean at time \eqn{t} is:
+#' \deqn{\log \mu_t = \log N_{t-1} + r - \alpha N_{t-1}}
+#' where \eqn{\alpha = \exp(\texttt{lalpha}) > 0}, ensuring negative density
+#' dependence. This is the likelihood used by fitting routines that optimize
+#' over a constrained parameter space.
+#'
+#' Unlike \code{\link{ricker_count_neg_ll}}, this function accepts \code{y}
+#' in several formats and constructs the lag pairs internally, so no separate
+#' model matrix needs to be supplied.
+#'
+#' @param theta Named numeric vector of parameters. Must contain:
+#'   \describe{
+#'     \item{\code{r}}{Intrinsic growth rate (unconstrained, real-valued).}
+#'     \item{\code{lalpha}}{Log of the intraspecific competition coefficient.
+#'       Exponentiated internally so that \eqn{\alpha = e^{\texttt{lalpha}} > 0}.}
+#'     \item{\code{lpsi}}{Log of the Negative Binomial dispersion parameter
+#'       (\eqn{\psi = e^{\texttt{lpsi}} > 0}). Required when \code{fam = "neg_binom"};
+#'       ignored otherwise.}
+#'   }
+#' @param y Observed count data. Accepted formats:
+#'   \describe{
+#'     \item{Numeric vector}{Raw time series. Lag pairs \code{(yt, ytm1)} are
+#'       constructed internally.}
+#'     \item{Data frame or matrix}{Must have named columns \code{yt} (count at
+#'       time \eqn{t}) and \code{ytm1} (count at time \eqn{t-1}), i.e., the
+#'       offset/lag-pair format used elsewhere in this package. Rows may come
+#'       from multiple concatenated series when using \code{off_patch} mode.}
+#'   }
+#'   \code{NA}s should be filled in before calling this function.
+#' @param X Ignored. Retained for interface compatibility with
+#'   \code{\link{ricker_count_neg_ll}}. Lag pairs are always derived from \code{y}.
+#' @param fam Error distribution family. One of \code{"poisson"} (default) or
+#'   \code{"neg_binom"}.
+#'
+#' @return Scalar negative log-likelihood evaluated at \code{theta}.
+#'
+#' @seealso \code{\link{ricker_count_neg_ll}} for the unconstrained version,
+#'   \code{\link{ricker_step}} for the deterministic Ricker step,
+#'   \code{\link{fit_ricker_cc}} and \code{\link{fit_ricker_EM}} which use
+#'   this function internally.
+#'
 ricker_count_neg_ll_cnstr <- function(theta, y, X = NULL, fam = "poisson"){
   
   if(is.vector(y)){
@@ -121,6 +167,24 @@ ricker_count_neg_ll_cnstr <- function(theta, y, X = NULL, fam = "poisson"){
 }
 
 
+#' Draw samples from a zero-truncated Poisson distribution
+#'
+#' Generates random draws from a Poisson distribution conditioned on the outcome
+#' being strictly positive (\eqn{X \geq 1}). Uses the inverse-CDF method: a
+#' uniform variate is drawn on \eqn{[p_0, 1]}, where \eqn{p_0 = P(X = 0)} under
+#' the untruncated Poisson, and then mapped through the Poisson quantile function.
+#' This guarantees all returned values are \eqn{\geq 1} without rejection sampling.
+#' Used during data augmentation to impute missing counts while avoiding zeros
+#' that would cause \eqn{\log(0)} in the likelihood.
+#'
+#' @param n Number of draws to return.
+#' @param lambda Rate parameter of the underlying (untruncated) Poisson distribution.
+#'   Must be positive.
+#'
+#' @return Integer vector of length \code{n} with all elements \eqn{\geq 1}.
+#'
+#' @seealso \code{\link{zt_neg_binom_rng}} for the Negative Binomial analogue.
+#'
 zt_poisson_rng <- function(n, lambda){
 
   p0 <- dpois(0, lambda = lambda)
@@ -132,6 +196,29 @@ zt_poisson_rng <- function(n, lambda){
 }
 
 
+#' Draw samples from a zero-truncated Negative Binomial distribution
+#'
+#' Generates random draws from a Negative Binomial distribution conditioned on
+#' the outcome being strictly positive (\eqn{X \geq 1}). Uses the same
+#' inverse-CDF method as \code{\link{zt_poisson_rng}}: a uniform variate is
+#' drawn on \eqn{[p_0, 1]}, where \eqn{p_0 = P(X = 0)} under the untruncated
+#' Negative Binomial, and then mapped through the NB quantile function.
+#' Used during data augmentation to impute missing counts under Negative
+#' Binomial error while avoiding zeros in the likelihood.
+#'
+#' @param n Number of draws to return.
+#' @param mu Mean of the underlying (untruncated) Negative Binomial distribution.
+#'   Must be positive. Corresponds to the \code{mu} parameterization in
+#'   \code{\link[stats]{dnbinom}}.
+#' @param size Dispersion (size) parameter of the Negative Binomial distribution
+#'   (\eqn{\psi} elsewhere in this package). Must be positive. Larger values
+#'   approach the Poisson limit.
+#'
+#' @return Integer vector of length \code{n} with all elements \eqn{\geq 1}.
+#'
+#' @seealso \code{\link{zt_poisson_rng}} for the Poisson analogue,
+#'   \code{\link[stats]{dnbinom}} for the parameterization used.
+#'
 zt_neg_binom_rng <- function(n, mu, size){
     p0 <- dnbinom(0, size = size, mu = mu)                                      
     u  <- runif(n, min = p0, max = 1)                                           

--- a/Functions/ricker_count_likelihood_functions.R
+++ b/Functions/ricker_count_likelihood_functions.R
@@ -15,7 +15,7 @@
 #' 
 ricker_step <- function(theta, Nt){
   return(
-    Nt * exp(theta[1] + theta[2] * Nt)
+    Nt * exp(theta[1] - theta[2] * Nt)
   )
 }
 
@@ -78,7 +78,12 @@ ricker_count_neg_ll_cnstr <- function(theta, y, X = NULL, fam = "poisson"){
       stop("Expecting an offset dataframe with columns yt and ytm1")
     }
     X <- y[, c("yt", "ytm1")]
-  } else {
+  } else if(is.matrix(y)){
+    if(!all(c("yt", "ytm1") %in% colnames(y))){
+      stop("Expecting an offset dataframe with columns yt and ytm1")
+    }
+    X <- y[, c("yt", "ytm1")]
+  } else{
     stop("y must be a vector or an offset dataframe with columns yt and ytm1")
   }
   
@@ -149,120 +154,5 @@ ricker_count_neg_ll_multi <- function(theta, y_list, X_list, fam = "poisson"){
   return(total_nll)
 }
 
-
-ricker_count_nb_fit <- function(theta, y, tol = 1e-5, max_iter = 500){
-  
-  if(is.vector(y)){
-    X <- data.frame(
-      yt = y[2:length(y)],
-      ytm1 = y[1:(length(y) - 1)]
-    )
-  } else if(is.data.frame(y)){
-    if(!all(c("yt", "ytm1") %in% names(y))){
-      stop("Expecting an offset dataframe with columns yt and ytm1")
-    }
-    X <- y[, c("yt", "ytm1")]
-  } else {
-    stop("y must be a vector or an offset dataframe with columns yt and ytm1")
-  }
-  
-  # ---- Objective functions ----
-  ## ---- Step 1 ----
-  step_1_obj_fun <- function(theta, X, psi){
-    n <- nrow(X) + 1
-    p <- length(theta)
-    
-    # constrained alpha
-    alpha <- exp(theta["lalpha"])
-    
-    # compute means
-    eta <- vector(mode = "double", length = n)
-    eta[1] <- log(X[1, "ytm1"])
-    
-    # compute means
-    for(t in 1:(n - 1)){
-      eta[t + 1] <- log(X[t, "ytm1"]) + theta["r"] - alpha * X[t, "ytm1"]
-    }
-    
-    # return the negative log-likelihood
-    return(-sum(
-      dnbinom(x = X[1:(n - 1), "yt"], mu = exp(eta[2:n]), size = psi, log = T)
-    ))
-  }
-  
-  ## ---- Step 2 ----
-  step_2_obj_fun <- function(lpsi, X, mu){
-    # return the negative log-likelihood
-    return(-sum(
-      dnbinom(x = X[1:(n - 1), "yt"], mu = mu, size = exp(lpsi), log = T)
-    ))
-  }
-  
-  # ---- Main loop ----
-  theta_curr <- theta[c("r", "lalpha")]
-  lpsi_curr <- theta["lpsi"]
-  H <- matrix(nrow = length(theta_curr), ncol = length(theta_curr))
-  i <- 0
-  diff <- 999
-  while(diff > tol & i < max_iter){
-    
-    # optimize r and lalpha
-    fit_i1 <- optim(theta_curr, step_1_obj_fun, X = X, psi = exp(lpsi_curr), hessian = T)
-    
-    theta_prop <- fit_i1$par
-    H <- fit_i1$hessian
-    
-    # now get mu for the current values
-    eta <- vector(mode = "double", length = n)
-    eta[1] <- log(X[1, "ytm1"])
-    
-    # compute means
-    for(t in 1:(n - 1)){
-      eta[t + 1] <- log(X[t, "ytm1"]) + theta_prop["r"] - exp(theta_prop["lalpha"]) * X[t, "ytm1"]
-    }
-    
-    fit_i2 <- optimize(step_2_obj_fun, interval = c(0, log(50)), X = X, mu = exp(eta))
-    
-    lpsi_prop <- fit_i2$minimum
-    
-    diff <- sqrt(sum(
-      (c(theta_curr, lpsi_curr) - c(theta_prop, lpsi_prop))^2
-    ))
-    i <- i + 1
-    theta_curr <- theta_prop
-    lpsi_curr <- lpsi_prop
-    
-  }
-  
-  # ---- compiling return objects ----
-  estims <- theta_curr
-  estims["lalpha"] <- exp(estims["lalpha"])
-  names(estims)[2] <- "alpha"
-  
-  # CIs and SEs
-  V <- solve(H)
-  ses <- sqrt(diag(V))
-  cis <- mapply(FUN = function(x, s){ x + c(-1, 1) * 2 * s }, x = theta_curr, s = ses)
-  # convert lalpha
-  cis[, 2] <- exp(cis[, 2])
-  cis <- t(cis)
-  colnames(cis) <- c("lower_95", "upper_95")
-  
-  # need to use the delta method for se of alpha
-  ses[2] <- sqrt(sqrt(ses[2]) * exp(theta_curr[2])^2)
-  names(ses) <- names(estims)
-  
-  return(
-    list(
-      estim = estims,
-      se = ses,
-      lower = as.double(cis[, 1]),
-      upper = as.double(cis[, 2]),
-      convergence = ifelse(i < max_iter, 0, 1),
-      psi = exp(lpsi_curr)
-    )
-  )
-  
-}
 
 

--- a/Functions/ricker_drop_function.R
+++ b/Functions/ricker_drop_function.R
@@ -1,5 +1,88 @@
 
 
+#' Fit Ricker count model with Poisson errors
+#'
+#' Estimates Ricker population model parameters under a Poisson observation
+#' model via a single call to \code{optim}. The intra-specific competition
+#' coefficient \eqn{\alpha} is constrained to be positive through the log
+#' parameterization \code{lalpha = log(alpha)}.
+#'
+#' The Ricker mean function is \eqn{\mu_t = y_{t-1} \exp(r - \alpha y_{t-1})},
+#' where counts at time \eqn{t} are assumed to follow a Poisson distribution
+#' with mean \eqn{\mu_t}.
+#'
+#' @param theta_init Named numeric vector of initial parameter values. Must
+#'   contain elements named \code{"r"} (intrinsic growth rate) and
+#'   \code{"lalpha"} (log of the intra-specific competition coefficient).
+#' @param y Either a numeric vector of population counts through time, or a
+#'   data frame with columns \code{yt} (count at time \eqn{t}) and
+#'   \code{ytm1} (count at time \eqn{t-1}). If a vector is supplied it is
+#'   converted internally to the lagged data frame format.
+#'
+#' @return A named list with the following elements:
+#'   \describe{
+#'     \item{\code{estim}}{Named numeric vector of point estimates for
+#'       \code{r} and \code{alpha} (back-transformed from \code{lalpha}).}
+#'     \item{\code{se}}{Named numeric vector of standard errors. The SE for
+#'       \code{alpha} is obtained via the delta method.}
+#'     \item{\code{lower}}{Numeric vector of lower 95\% confidence limits for
+#'       \code{r} and \code{alpha}.}
+#'     \item{\code{upper}}{Numeric vector of upper 95\% confidence limits for
+#'       \code{r} and \code{alpha}.}
+#'     \item{\code{working}}{Named numeric vector of estimates on the working
+#'       (log) scale, i.e. \code{r} and \code{lalpha}.}
+#'     \item{\code{V}}{Variance-covariance matrix of the working-scale
+#'       estimates, derived from the inverse Hessian returned by
+#'       \code{optim}.}
+#'     \item{\code{convergence}}{Integer convergence flag from \code{optim}:
+#'       \code{0} indicates successful convergence.}
+#'   }
+#'
+#' @examples
+#' y <- readRDS("data/missingDatasets/pois_sim_randMiss_A.rds")[[1]]$y[[1]]
+#' init <- c(r = 1, lalpha = log(0.01))
+#' ricker_count_pois_fit(theta_init = init, y = y)
+#'
+ricker_count_pois_fit <- function(theta_init, y){
+  
+  fit <- optim(theta_init, ricker_count_neg_ll_cnstr, y = y, fam = "poisson", hessian = T)
+  
+  # compile results
+  estims <- fit$par
+  estims["lalpha"] <- exp(estims["lalpha"])
+  names(estims)[2] <- "alpha"
+  
+  # CIs and SEs
+  V <- solve(fit$hessian)
+  ses <- sqrt(diag(V))
+  cis <- mapply(FUN = function(x, s){ x + c(-1, 1) * 2 * s }, x = fit$par, s = ses)
+  # convert lalpha
+  cis[, 2] <- exp(cis[, 2])
+  cis <- t(cis)
+  colnames(cis) <- c("lower_95", "upper_95")
+  
+  # need to use the delta method for se of alpha
+  ses[2] <- sqrt(sqrt(ses[2]) * exp(fit$par[2])^2)
+  names(ses) <- names(estims)
+  
+  return(
+    list(
+      estim = estims,
+      se = ses,
+      lower = as.double(cis[, 1]),
+      upper = as.double(cis[, 2]),
+      working = fit$par,
+      V = V,
+      convergence = fit$convergence,
+      nll = fit$value
+    )
+  )
+  
+}
+
+
+
+
 #' Fit Ricker count model with negative binomial errors via alternating optimization
 #'
 #' Estimates Ricker population model parameters under a negative binomial
@@ -71,24 +154,22 @@ ricker_count_nb_fit <- function(theta, y, tol = 1e-5, max_iter = 500){
   # ---- Objective functions ----
   ## ---- Step 1 ----
   step_1_obj_fun <- function(theta, X, psi){
-    n <- nrow(X) + 1
-    p <- length(theta)
     
     # constrained alpha
     alpha <- exp(theta["lalpha"])
     
     # compute means
-    eta <- vector(mode = "double", length = n)
+    eta <- vector(mode = "double", length = nrow(X) + 1)
     eta[1] <- log(X[1, "ytm1"])
     
     # compute means
-    for(t in 1:(n - 1)){
+    for(t in 1:nrow(X)){
       eta[t + 1] <- log(X[t, "ytm1"]) + theta["r"] - alpha * X[t, "ytm1"]
     }
     
     # return the negative log-likelihood
     return(-sum(
-      dnbinom(x = X[1:(n - 1), "yt"], mu = exp(eta[2:n]), size = psi, log = T)
+      dnbinom(x = X[["yt"]], mu = exp(eta[2:length(eta)]), size = psi, log = T)
     ))
   }
   
@@ -96,7 +177,7 @@ ricker_count_nb_fit <- function(theta, y, tol = 1e-5, max_iter = 500){
   step_2_obj_fun <- function(lpsi, X, mu){
     # return the negative log-likelihood
     return(-sum(
-      dnbinom(x = X[1:(n - 1), "yt"], mu = mu, size = exp(lpsi), log = T)
+      dnbinom(x = X[["yt"]], mu = mu, size = exp(lpsi), log = T)
     ))
   }
   
@@ -115,15 +196,15 @@ ricker_count_nb_fit <- function(theta, y, tol = 1e-5, max_iter = 500){
     H <- fit_i1$hessian
     
     # now get mu for the current values
-    eta <- vector(mode = "double", length = n)
+    eta <- vector(mode = "double", length = nrow(X) + 1)
     eta[1] <- log(X[1, "ytm1"])
     
     # compute means
-    for(t in 1:(n - 1)){
+    for(t in 1:nrow(X)){
       eta[t + 1] <- log(X[t, "ytm1"]) + theta_prop["r"] - exp(theta_prop["lalpha"]) * X[t, "ytm1"]
     }
     
-    fit_i2 <- optimize(step_2_obj_fun, interval = c(0, log(50)), X = X, mu = exp(eta))
+    fit_i2 <- optimize(step_2_obj_fun, interval = c(-5, 5), X = X, mu = exp(eta))
     
     lpsi_prop <- fit_i2$minimum
     
@@ -160,7 +241,10 @@ ricker_count_nb_fit <- function(theta, y, tol = 1e-5, max_iter = 500){
       se = c(ses, psi = NA_real_),
       lower = c(as.double(cis[, 1]), psi = NA_real_),
       upper = c(as.double(cis[, 2]), psi = NA_real_),
-      convergence = ifelse(i < max_iter, 0, 1)
+      working = c(theta_curr, lpsi_curr),
+      V = V,
+      convergence = ifelse(i < max_iter, 0, 1),
+      nll = fit_i1$value
     )
   )
   
@@ -247,25 +331,7 @@ fit_ricker_cc <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
   # ---- fit with poisson ----
   if(fam == "poisson"){
     init <- c(r = 1, lalpha = log(0.01))
-    fit <- optim(init, ricker_count_neg_ll_cnstr, y = dat_cc, fam = "poisson", hessian = T)
-    
-    # compile results
-    estims <- fit$par
-    estims["lalpha"] <- exp(estims["lalpha"])
-    names(estims)[2] <- "alpha"
-    
-    # CIs and SEs
-    V <- solve(fit$hessian)
-    ses <- sqrt(diag(V))
-    cis <- mapply(FUN = function(x, s){ x + c(-1, 1) * 2 * s }, x = fit$par, s = ses)
-    # convert lalpha
-    cis[, 2] <- exp(cis[, 2])
-    cis <- t(cis)
-    colnames(cis) <- c("lower_95", "upper_95")
-    
-    # need to use the delta method for se of alpha
-    ses[2] <- sqrt(sqrt(ses[2]) * exp(fit$par[2])^2)
-    names(ses) <- names(estims)
+    fit <- ricker_count_pois_fit(init, dat_cc)
   }
   
   # ---- or fit with negbinom ----
@@ -278,59 +344,52 @@ fit_ricker_cc <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
   # no need for 1000 betas for projection CI
   if(pro_conf=="none"){
     # return as a list
-    return(list(
-      estim = estims,
-      se = ses,
-      lower = as.double(cis[, 1]),
-      upper = as.double(cis[, 2]),
-      convergence = fit$convergence
-    ))
+    return( fit[-which(names(fit) %in% c("working", "V"))] )
   }
   
-  # simulated 1000 betas for projection CI
+  # ---- Many betas ----
+  ## ---- Fiducial draws ----
   if(pro_conf=="sim"){
     sim_per_fit=1000
     
     # draws from Fiducial distribution
-    CI_results=mvrnorm(sim_per_fit, fit$par, V)  # Generate random samples
+    # put alpha back on log scale
+    CI_results=mvrnorm(sim_per_fit, fit$working, fit$V)  # Generate random samples
     if("lalpha" %in% colnames(CI_results)){
       CI_results[, "lalpha"] <- exp(CI_results[, "lalpha"])
-      colnames(CI_results) <- names(estims)
+      colnames(CI_results) <- names(fit$estim)
     }
     
     # return as a list
-    return(list(
-      estim = estims,
-      se = ses,
-      lower = as.double(cis[, 1]),
-      upper = as.double(cis[, 2]),
-      CI_results=CI_results
+    return(c(
+      fit[-which(names(fit) %in% c("working", "V"))],
+      list(CI_results=CI_results)
     ))
     
   }
   
-  # bootstrapped 1000 betas for projection CI
+  ## ---- bootstrapped betas ----
   if(pro_conf=="boot"){
     sim_per_fit=1000
     
     boot = function(x, y, f){
       data_sample = y[sample(seq_len(nrow(y)), replace = TRUE), ]
       init <- c(r = 1, lalpha = log(0.01))
-      fit_s <- optim(init, ricker_count_neg_ll_cnstr, y = data_sample, fam = f, hessian = T)
-      return(fit_s$par)
+      if(f == "neg_binom"){
+        init <- c(init, lpsi = log(4))
+        fit_s <- ricker_count_nb_fit(init, data_sample)
+      } else {
+        fit_s <- ricker_count_pois_fit(init, data_sample)
+      }
+      return(fit_s$estim)
     }
     
     CI_results <- do.call(rbind, lapply(1:sim_per_fit, boot, dat_cc, f = fam))
-    CI_results[, "lalpha"] <- exp(CI_results[, "lalpha"])
-    colnames(CI_results) <- names(estims)
     
     # return as a list
-    return(list(
-      estim = estims,
-      se = ses,
-      lower = as.double(cis[, 1]),
-      upper = as.double(cis[, 2]),
-      CI_results=CI_results
+    return(c(
+      fit[-which(names(fit) %in% c("working", "V"))],
+      list(CI_results=CI_results)
     ))
   }
   
@@ -356,11 +415,11 @@ fit_ricker_cc <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
 #' y <- readRDS("data/missingDatasets/pois_sim_randMiss_A.rds")[[1]]$y[[1]]
 #' fit_ricker_cc(y)
 #' 
-fit_ricker_drop <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
+fit_ricker_drop <- function(y, fam = "poisson", pro_conf="none", off_patch=F, patch_col = "patch"){
   
   if(off_patch){ # we have taken in already offset patch data
     y0=y
-    y=as.numeric(y0[,1])
+    y=as.numeric(c(y0[1, "ytm1"], y0[, "yt"]))
   }
   
   # Check for population extinction
@@ -373,7 +432,7 @@ fit_ricker_drop <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
   }
   
   # Check for NaN
-  if(any(is.nan(y),na.rm=T)){
+  if(any(is.nan(y), na.rm=T)){
     warning("NaN found, recode missing data as NA, returning NA")
     return(list(
       NA,
@@ -406,28 +465,20 @@ fit_ricker_drop <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
   
   if(off_patch){ # we have taken in already offset patch data
     
-    patches=unique(y0$patchv)
-    dat=data.frame(matrix(data=NA,nrow=0,ncol=2))
-    for(i in 1:length(patches)){
-      patch_i=which(y0$patchv==patches[i])
-      print(patch_i)
-      y_cc=y0$ytm1[patch_i][complete.cases(y0$ytm1[patch_i])]
-      print(y_cc)
-      n=length(y_cc)
-      if(n<2){
-        # skip
-      } else {
-        dat_i <- data.frame(
-          yt = y_cc[2:n],
-          ytm1 = y_cc[1:(n - 1)]
-        )
-        print(dat_i)
-        dat=rbind(dat,dat_i)
-      }
-
+    patches=unique(y0[, patch_col])
+    dat_split <- lapply(patches, function(p, df){ df[df[patch_col] == p, ] }, df = y0)
+    dat <- data.frame()
+    for(y in dat_split){
+      y_i <- c(y[1, "ytm1"], y[, "yt"])
+      y_i <- y_i[complete.cases(y_i)]
+      df_i <- data.frame(
+        yt = y_i[2:length(y_i)],
+        ytm1 = y_i[1:(length(y_i) - 1)],
+        patch_col = unique(y[[patch_col]])
+      )
+      dat <- rbind(dat, df_i)
     }
-    
-    colnames(dat)=c("yt","ytm1")
+
   } else {
     n <- length(y)
     # compile into sliced dataframe
@@ -439,89 +490,66 @@ fit_ricker_drop <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
   
   # ---- fit with poisson ----
   if(fam == "poisson"){
-    fit <- glm(
-      yt ~ ytm1, data = dat, 
-      family = poisson,
-      offset = log(ytm1)
-    )
+    init <- c(r = 1, lalpha = log(0.01))
+    fit <- ricker_count_pois_fit(init, dat)
   }
   
-  # or fit with negbinom
+  # ---- or fit with negbinom ----
   if(fam == "neg_binom"){
-    fit <- MASS::glm.nb(
-      yt ~ ytm1 + offset(log(ytm1)), 
-      data = dat
-    )
+    init <- c(r = 1, lalpha = log(0.01), lpsi = log(4))
+    fit <- ricker_count_nb_fit(init, dat)
   }
   
-  # compile objects and rename
-  estims <- coef(fit)
-  names(estims) <- c("r", "alpha")
-  cis <- confint(fit)
-  rownames(cis) <- names(estims)
-  ses <- sqrt(diag(vcov(fit)))
-  names(ses) <- names(estims)
-  
-
   
   # no need for 1000 betas for projection CI
   if(pro_conf=="none"){
     # return as a list
-    return(list(
-      estim = estims * c(1, -1),
-      se = ses,
-      lower = as.double(diag(cis) * c(1, -1)),
-      upper = as.double(
-        c(cis[1,2], cis[2,1]) * c(1, -1)
-      )
-    ))
+    return( fit[-which(names(fit) %in% c("working", "V"))] )
   }
   
-  # simulated 1000 betas for projection CI
+  # ---- Many betas ----
+  ## ---- Fiducial draws ----
   if(pro_conf=="sim"){
     sim_per_fit=1000
     
-    betas <- coef(fit)     # Get coefficients
-    vcov_mat <- vcov(fit)  # Get variance-covariance matrix
-    CI_results=mvrnorm(sim_per_fit, betas, vcov_mat)  # Generate random samples
-    
+    # draws from Fiducial distribution
+    # put alpha back on log scale
+    CI_results=mvrnorm(sim_per_fit, fit$working, fit$V)  # Generate random samples
+    if("lalpha" %in% colnames(CI_results)){
+      CI_results[, "lalpha"] <- exp(CI_results[, "lalpha"])
+      colnames(CI_results) <- names(fit$estim)
+    }
     
     # return as a list
-    return(list(
-      estim = estims * c(1, -1),
-      se = ses,
-      lower = as.double(diag(cis) * c(1, -1)),
-      upper = as.double(
-        c(cis[1,2], cis[2,1]) * c(1, -1)
-      ),
-      CI_results=CI_results
+    return(c(
+      fit[-which(names(fit) %in% c("working", "V"))],
+      list(CI_results=CI_results)
     ))
     
   }
   
-  # bootstrapped 1000 betas for projection CI
+  ## ---- bootstrapped betas ----
   if(pro_conf=="boot"){
     sim_per_fit=1000
     
-    boot = function(x, model){
-      data = model.frame(model)
-      data_sample = data[sample(seq_len(nrow(data)), replace = TRUE), ]
-      names(data_sample)=c("yt","ytm1","offset")
-      coef(update(model, data = data_sample))
+    boot = function(x, y, f){
+      data_sample = y[sample(seq_len(nrow(y)), replace = TRUE), ]
+      init <- c(r = 1, lalpha = log(0.01))
+      if(f == "neg_binom"){
+        init <- c(init, lpsi = log(4))
+        fit_s <- ricker_count_nb_fit(init, data_sample)
+      } else {
+        fit_s <- ricker_count_pois_fit(init, data_sample)
+      }
+      return(fit_s$estim)
     }
     
-    CI_results <- do.call(rbind, lapply(1:sim_per_fit, boot, fit))
-   
+    CI_results <- do.call(rbind, lapply(1:sim_per_fit, boot, dat_cc, f = fam))
     
     # return as a list
-    return(list(
-      estim = estims * c(1, -1),
-      se = ses,
-      lower = as.double(diag(cis) * c(1, -1)),
-      upper = as.double(
-        c(cis[1,2], cis[2,1]) * c(1, -1)
-      ),
-      CI_results=CI_results
+    return(c(
+      fit[-which(names(fit) %in% c("working", "V"))],
+      list(CI_results=CI_results)
     ))
   }
   

--- a/Functions/ricker_drop_function.R
+++ b/Functions/ricker_drop_function.R
@@ -1,5 +1,172 @@
 
 
+#' Fit Ricker count model with negative binomial errors via alternating optimization
+#'
+#' Estimates Ricker population model parameters under a negative binomial
+#' observation model using a two-step alternating optimization scheme.
+#' In step 1, the intrinsic growth rate (\code{r}) and log-transformed
+#' intra-specific competition coefficient (\code{lalpha}) are optimized
+#' conditional on the current overdispersion estimate. In step 2, the
+#' log-overdispersion parameter (\code{lpsi}) is optimized conditional on
+#' the current predicted means. The two steps alternate until parameter
+#' estimates converge or the iteration limit is reached.
+#'
+#' The Ricker mean function is \eqn{\mu_t = y_{t-1} \exp(r - \alpha y_{t-1})},
+#' where \eqn{\alpha} is constrained to be positive via the log
+#' parameterization \code{lalpha = log(alpha)}.
+#'
+#' @param theta Named numeric vector of initial parameter values. Must contain
+#'   elements named \code{"r"} (intrinsic growth rate), \code{"lalpha"}
+#'   (log of the intra-specific competition coefficient), and \code{"lpsi"}
+#'   (log of the negative binomial overdispersion parameter).
+#' @param y Either a numeric vector of population counts through time, or a
+#'   data frame with columns \code{yt} (count at time \eqn{t}) and
+#'   \code{ytm1} (count at time \eqn{t-1}). If a vector is supplied it is
+#'   automatically converted to the lagged data frame format.
+#' @param tol Numeric scalar. Convergence tolerance; the Euclidean distance
+#'   between successive parameter vectors must fall below this value for the
+#'   algorithm to be considered converged. Defaults to \code{1e-5}.
+#' @param max_iter Integer. Maximum number of alternating-optimization
+#'   iterations before the algorithm stops regardless of convergence.
+#'   Defaults to \code{500}.
+#'
+#' @return A named list with the following elements:
+#'   \describe{
+#'     \item{\code{estim}}{Named numeric vector of point estimates for
+#'       \code{r}, \code{alpha} (back-transformed from \code{lalpha}), and
+#'       \code{psi} (back-transformed from \code{lpsi}).}
+#'     \item{\code{se}}{Named numeric vector of standard errors for \code{r}
+#'       and \code{alpha}. The SE for \code{alpha} is obtained via the delta
+#'       method. \code{psi} SE is \code{NA} as it is estimated via
+#'       \code{optimize()} without a Hessian.}
+#'     \item{\code{lower}}{Numeric vector of lower 95\% confidence limits for
+#'       \code{r} and \code{alpha}. \code{psi} lower limit is \code{NA}.}
+#'     \item{\code{upper}}{Numeric vector of upper 95\% confidence limits for
+#'       \code{r} and \code{alpha}. \code{psi} upper limit is \code{NA}.}
+#'     \item{\code{convergence}}{Integer flag: \code{0} if the algorithm
+#'       converged within \code{max_iter} iterations, \code{1} otherwise.}
+#'   }
+#'
+#' @examples
+#' y <- readRDS("data/missingDatasets/nb_sim_randMiss_A.rds")[[1]]$y[[1]]
+#' init <- c(r = 1, lalpha = log(0.01), lpsi = log(5))
+#' ricker_count_nb_fit(theta = init, y = y)
+#'
+ricker_count_nb_fit <- function(theta, y, tol = 1e-5, max_iter = 500){
+  
+  if(is.vector(y)){
+    X <- data.frame(
+      yt = y[2:length(y)],
+      ytm1 = y[1:(length(y) - 1)]
+    )
+  } else if(is.data.frame(y)){
+    if(!all(c("yt", "ytm1") %in% names(y))){
+      stop("Expecting an offset dataframe with columns yt and ytm1")
+    }
+    X <- y[, c("yt", "ytm1")]
+  } else {
+    stop("y must be a vector or an offset dataframe with columns yt and ytm1")
+  }
+  
+  # ---- Objective functions ----
+  ## ---- Step 1 ----
+  step_1_obj_fun <- function(theta, X, psi){
+    n <- nrow(X) + 1
+    p <- length(theta)
+    
+    # constrained alpha
+    alpha <- exp(theta["lalpha"])
+    
+    # compute means
+    eta <- vector(mode = "double", length = n)
+    eta[1] <- log(X[1, "ytm1"])
+    
+    # compute means
+    for(t in 1:(n - 1)){
+      eta[t + 1] <- log(X[t, "ytm1"]) + theta["r"] - alpha * X[t, "ytm1"]
+    }
+    
+    # return the negative log-likelihood
+    return(-sum(
+      dnbinom(x = X[1:(n - 1), "yt"], mu = exp(eta[2:n]), size = psi, log = T)
+    ))
+  }
+  
+  ## ---- Step 2 ----
+  step_2_obj_fun <- function(lpsi, X, mu){
+    # return the negative log-likelihood
+    return(-sum(
+      dnbinom(x = X[1:(n - 1), "yt"], mu = mu, size = exp(lpsi), log = T)
+    ))
+  }
+  
+  # ---- Main loop ----
+  theta_curr <- theta[c("r", "lalpha")]
+  lpsi_curr <- theta["lpsi"]
+  H <- matrix(nrow = length(theta_curr), ncol = length(theta_curr))
+  i <- 0
+  diff <- 999
+  while(diff > tol & i < max_iter){
+    
+    # optimize r and lalpha
+    fit_i1 <- optim(theta_curr, step_1_obj_fun, X = X, psi = exp(lpsi_curr), hessian = T)
+    
+    theta_prop <- fit_i1$par
+    H <- fit_i1$hessian
+    
+    # now get mu for the current values
+    eta <- vector(mode = "double", length = n)
+    eta[1] <- log(X[1, "ytm1"])
+    
+    # compute means
+    for(t in 1:(n - 1)){
+      eta[t + 1] <- log(X[t, "ytm1"]) + theta_prop["r"] - exp(theta_prop["lalpha"]) * X[t, "ytm1"]
+    }
+    
+    fit_i2 <- optimize(step_2_obj_fun, interval = c(0, log(50)), X = X, mu = exp(eta))
+    
+    lpsi_prop <- fit_i2$minimum
+    
+    diff <- sqrt(sum(
+      (c(theta_curr, lpsi_curr) - c(theta_prop, lpsi_prop))^2
+    ))
+    i <- i + 1
+    theta_curr <- theta_prop
+    lpsi_curr <- lpsi_prop
+    
+  }
+  
+  # ---- compiling return objects ----
+  estims <- theta_curr
+  estims["lalpha"] <- exp(estims["lalpha"])
+  names(estims)[2] <- "alpha"
+  
+  # CIs and SEs
+  V <- solve(H)
+  ses <- sqrt(diag(V))
+  cis <- mapply(FUN = function(x, s){ x + c(-1, 1) * 2 * s }, x = theta_curr, s = ses)
+  # convert lalpha
+  cis[, 2] <- exp(cis[, 2])
+  cis <- t(cis)
+  colnames(cis) <- c("lower_95", "upper_95")
+  
+  # need to use the delta method for se of alpha
+  ses[2] <- sqrt(sqrt(ses[2]) * exp(theta_curr[2])^2)
+  names(ses) <- names(estims)
+  
+  return(
+    list(
+      estim = c(estims, psi = exp(lpsi_curr)),
+      se = c(ses, psi = NA_real_),
+      lower = c(as.double(cis[, 1]), psi = NA_real_),
+      upper = c(as.double(cis[, 2]), psi = NA_real_),
+      convergence = ifelse(i < max_iter, 0, 1)
+    )
+  )
+  
+}
+
+
 #' Fit Ricker count model with complete cases only
 #'
 #' @param y Vector of population counts through time. NA should be used for missing data.
@@ -77,43 +244,37 @@ fit_ricker_cc <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
     ))
   }
   
-  # fit with poisson
+  # ---- fit with poisson ----
   if(fam == "poisson"){
-    fit <- glm(
-      yt ~ ytm1, data = dat_cc, 
-      family = poisson,
-      offset = log(ytm1)
-    )
+    init <- c(r = 1, lalpha = log(0.01))
+    fit <- optim(init, ricker_count_neg_ll_cnstr, y = dat_cc, fam = "poisson", hessian = T)
+    
+    # compile results
+    estims <- fit$par
+    estims["lalpha"] <- exp(estims["lalpha"])
+    names(estims)[2] <- "alpha"
+    
+    # CIs and SEs
+    V <- solve(fit$hessian)
+    ses <- sqrt(diag(V))
+    cis <- mapply(FUN = function(x, s){ x + c(-1, 1) * 2 * s }, x = fit$par, s = ses)
+    # convert lalpha
+    cis[, 2] <- exp(cis[, 2])
+    cis <- t(cis)
+    colnames(cis) <- c("lower_95", "upper_95")
+    
+    # need to use the delta method for se of alpha
+    ses[2] <- sqrt(sqrt(ses[2]) * exp(fit$par[2])^2)
+    names(ses) <- names(estims)
   }
   
-  # or fit with negbinom
+  # ---- or fit with negbinom ----
   if(fam == "neg_binom"){
-    fit <- MASS::glm.nb(
-      yt ~ ytm1 + offset(log(ytm1)), 
-      data = dat_cc
-    )
+    init <- c(r = 1, lalpha = log(0.01), lpsi = log(4))
+    fit <- ricker_count_nb_fit(init, dat_cc)
   }
-  
-  # compile objects and rename
-  estims <- coef(fit)
-  cis <- confint(fit)
-  ses <- sqrt(diag(vcov(fit)))
-  names(estims) <- c("r", "alpha")
-  if(fam == "neg_binom"){
-    estims <- c(estims, fit$theta)
-    names(estims)[3] <- "psi"
-    cis <- rbind(cis, rep(NA, ncol(cis)))
-    ses <- c(ses, NA)
-  }
-  rownames(cis) <- names(estims)
-  names(ses) <- names(estims)
-  
-  # change sign of alpha
-  estims["alpha"] <- estims["alpha"] * -1
-  cis[rownames(cis) == "alpha", c(2, 1)] <- cis[rownames(cis) == "alpha", ] * -1
   
 
-  
   # no need for 1000 betas for projection CI
   if(pro_conf=="none"){
     # return as a list
@@ -121,7 +282,8 @@ fit_ricker_cc <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
       estim = estims,
       se = ses,
       lower = as.double(cis[, 1]),
-      upper = as.double(cis[, 2])
+      upper = as.double(cis[, 2]),
+      convergence = fit$convergence
     ))
   }
   
@@ -129,10 +291,12 @@ fit_ricker_cc <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
   if(pro_conf=="sim"){
     sim_per_fit=1000
     
-    betas <- coef(fit)     # Get coefficients
-    vcov_mat <- vcov(fit)  # Get variance-covariance matrix
-    CI_results=mvrnorm(sim_per_fit, betas, vcov_mat)  # Generate random samples
-    
+    # draws from Fiducial distribution
+    CI_results=mvrnorm(sim_per_fit, fit$par, V)  # Generate random samples
+    if("lalpha" %in% colnames(CI_results)){
+      CI_results[, "lalpha"] <- exp(CI_results[, "lalpha"])
+      colnames(CI_results) <- names(estims)
+    }
     
     # return as a list
     return(list(
@@ -149,15 +313,16 @@ fit_ricker_cc <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
   if(pro_conf=="boot"){
     sim_per_fit=1000
     
-    boot = function(x, model){
-      data = model.frame(model)
-      data_sample = data[sample(seq_len(nrow(data)), replace = TRUE), ]
-      names(data_sample)=c("yt","ytm1","offset")
-      coef(update(model, data = data_sample))
+    boot = function(x, y, f){
+      data_sample = y[sample(seq_len(nrow(y)), replace = TRUE), ]
+      init <- c(r = 1, lalpha = log(0.01))
+      fit_s <- optim(init, ricker_count_neg_ll_cnstr, y = data_sample, fam = f, hessian = T)
+      return(fit_s$par)
     }
     
-    CI_results <- do.call(rbind, lapply(1:sim_per_fit, boot, fit))
-    
+    CI_results <- do.call(rbind, lapply(1:sim_per_fit, boot, dat_cc, f = fam))
+    CI_results[, "lalpha"] <- exp(CI_results[, "lalpha"])
+    colnames(CI_results) <- names(estims)
     
     # return as a list
     return(list(
@@ -272,7 +437,7 @@ fit_ricker_drop <- function(y, fam = "poisson", pro_conf="none", off_patch=F){
     )
   }
   
-  # fit with poisson
+  # ---- fit with poisson ----
   if(fam == "poisson"){
     fit <- glm(
       yt ~ ytm1, data = dat, 

--- a/ModelChecking/checking_ricker_constrained_pars.R
+++ b/ModelChecking/checking_ricker_constrained_pars.R
@@ -30,9 +30,19 @@ fit2_da <- fit_ricker_DA(y2)
 
 ## ---- multi-series ----
 
-y3 <- lapply(1:5, \(i) { ricker_sim(50, 0.8, 0.01, N0 = rpois(1, 10), err_fam = "poisson") })
+y3 <- lapply(1:5, \(i) { ricker_sim(50, 0.8, 0.01, N0 = rpois(1, 15), err_fam = "poisson") })
 for(i in 1:length(y3)){
   y3[[i]][sample(1:length(y3[[i]]), size = rpois(1, 5))] <- NA
+  # remove starting NAs
+  if(is.na(y3[[i]][1])){
+    start <- 1
+    j <- 1
+    while(is.na(y3[[i]][j])){
+      start <- start + 1
+      j <- j + 1
+    }
+    y3[[i]] <- y3[[i]][-(1:(start - 1))]
+  }
 }
 
 y_df <- lapply(1:length(y3), function(i, y){
@@ -48,6 +58,7 @@ y_df <- Reduce(rbind, y_df)
 fit3 <- fit_ricker_cc(y_df, off_patch = T)
 fit3_d <- fit_ricker_drop(y_df, off_patch = T, patch_col = "patch")
 fit3_em <- fit_ricker_EM(y_df, off_patch = T)
+fit3_da <- fit_ricker_DA(y_df, off_patch = T)
 
 
 # ---- one-off Negative Binomial testing ----
@@ -58,6 +69,8 @@ y_nb <- ricker_sim(50, 0.8, 0.01, N0 = 20, err_fam = "neg_binom", psi = 5)
 
 fit_nb <- fit_ricker_cc(y_nb, fam = "neg_binom")
 fit_nb_d <- fit_ricker_drop(y_nb, fam = "neg_binom")
+fit_nb_em <- fit_ricker_EM(y_nb, fam = "neg_binom")
+fit_nb_da <- fit_ricker_DA(y_nb, fam = "neg_binom")
 
 ## ---- Some missing ----
 
@@ -66,6 +79,8 @@ y2_nb[sample(1:length(y_nb), size = 6)] <- NA
 
 fit2_nb <- fit_ricker_cc(y2_nb, fam = "neg_binom")
 fit2_nb_d <- fit_ricker_drop(y2_nb, fam = "neg_binom")
+fit2_nb_em <- fit_ricker_EM(y2_nb, fam = "neg_binom")
+fit2_nb_da <- fit_ricker_DA(y2_nb, fam = "neg_binom")
 
 
 ## ---- multi-series ----
@@ -73,6 +88,16 @@ fit2_nb_d <- fit_ricker_drop(y2_nb, fam = "neg_binom")
 y3_nb <- lapply(1:5, \(i) { ricker_sim(50, 0.8, 0.01, N0 = rpois(1, 10), err_fam = "neg_binom", psi = 5) })
 for(i in 1:length(y3_nb)){
   y3_nb[[i]][sample(1:length(y3_nb[[i]]), size = rpois(1, 5))] <- NA
+  # remove starting NAs
+  if(is.na(y3_nb[[i]][1])){
+    start <- 1
+    j <- 1
+    while(is.na(y3_nb[[i]][j])){
+      start <- start + 1
+      j <- j + 1
+    }
+    y3_nb[[i]] <- y3_nb[[i]][-(1:(start - 1))]
+  }
 }
 
 y_df_nb <- lapply(1:length(y3_nb), function(i, y){
@@ -87,8 +112,8 @@ y_df_nb <- Reduce(rbind, y_df_nb)
 
 fit3_nb <- fit_ricker_cc(y_df_nb, off_patch = T, fam = "neg_binom")
 fit3_nb_d <- fit_ricker_drop(y_df_nb, off_patch = T, patch_col = "patch", fam = "neg_binom")
-
-
+fit3_nb_em <- fit_ricker_drop(y_df_nb, off_patch = T, fam = "neg_binom")
+fit3_nb_da <- fit_ricker_DA(y_df_nb, off_patch = T, fam = "neg_binom")
 
 
 

--- a/ModelChecking/checking_ricker_constrained_pars.R
+++ b/ModelChecking/checking_ricker_constrained_pars.R
@@ -1,0 +1,17 @@
+
+# test
+
+library(tidyverse)
+
+flist <- list.files("Functions/", pattern = "\\.R$", full.names = T)
+lapply(flist, source)
+
+# ---- one-off Poisson testing ----
+
+## ---- No missing ----
+
+y <- ricker_sim(50, 0.8, 0.01, N0 = 20, err_fam = "poisson")
+
+init <- c(r=0.5, lalpha=log(0.02))
+
+fit <- optim(init, ricker_count_neg_ll_cnstr, y = y, fam = "poisson", hessian = T)

--- a/ModelChecking/checking_ricker_constrained_pars.R
+++ b/ModelChecking/checking_ricker_constrained_pars.R
@@ -12,6 +12,87 @@ lapply(flist, source)
 
 y <- ricker_sim(50, 0.8, 0.01, N0 = 20, err_fam = "poisson")
 
-init <- c(r=0.5, lalpha=log(0.02))
+fit <- fit_ricker_cc(y)
+fit_d <- fit_ricker_drop(y)
+fit_em <- fit_ricker_EM(y)
+fit_da <- fit_ricker_DA(y)
 
-fit <- optim(init, ricker_count_neg_ll_cnstr, y = y, fam = "poisson", hessian = T)
+## ---- Some missing ----
+
+y2 <- y
+y2[sample(1:length(y), size = 6)] <- NA
+
+fit2 <- fit_ricker_cc(y2)
+fit2_d <- fit_ricker_drop(y2)
+fit2_em <- fit_ricker_EM(y2)
+fit2_da <- fit_ricker_DA(y2)
+
+
+## ---- multi-series ----
+
+y3 <- lapply(1:5, \(i) { ricker_sim(50, 0.8, 0.01, N0 = rpois(1, 10), err_fam = "poisson") })
+for(i in 1:length(y3)){
+  y3[[i]][sample(1:length(y3[[i]]), size = rpois(1, 5))] <- NA
+}
+
+y_df <- lapply(1:length(y3), function(i, y){
+  data.frame(
+    yt = y[[i]][2:length(y[[i]])],
+    ytm1 = y[[i]][1:(length(y[[i]]) - 1)],
+    patch = as.character(i)
+  )
+}, y = y3)
+
+y_df <- Reduce(rbind, y_df)
+
+fit3 <- fit_ricker_cc(y_df, off_patch = T)
+fit3_d <- fit_ricker_drop(y_df, off_patch = T, patch_col = "patch")
+fit3_em <- fit_ricker_EM(y_df, off_patch = T)
+
+
+# ---- one-off Negative Binomial testing ----
+
+## ---- No missing ----
+
+y_nb <- ricker_sim(50, 0.8, 0.01, N0 = 20, err_fam = "neg_binom", psi = 5)
+
+fit_nb <- fit_ricker_cc(y_nb, fam = "neg_binom")
+fit_nb_d <- fit_ricker_drop(y_nb, fam = "neg_binom")
+
+## ---- Some missing ----
+
+y2_nb <- y_nb
+y2_nb[sample(1:length(y_nb), size = 6)] <- NA
+
+fit2_nb <- fit_ricker_cc(y2_nb, fam = "neg_binom")
+fit2_nb_d <- fit_ricker_drop(y2_nb, fam = "neg_binom")
+
+
+## ---- multi-series ----
+
+y3_nb <- lapply(1:5, \(i) { ricker_sim(50, 0.8, 0.01, N0 = rpois(1, 10), err_fam = "neg_binom", psi = 5) })
+for(i in 1:length(y3_nb)){
+  y3_nb[[i]][sample(1:length(y3_nb[[i]]), size = rpois(1, 5))] <- NA
+}
+
+y_df_nb <- lapply(1:length(y3_nb), function(i, y){
+  data.frame(
+    yt = y[[i]][2:length(y[[i]])],
+    ytm1 = y[[i]][1:(length(y[[i]]) - 1)],
+    patch = as.character(i)
+  )
+}, y = y3_nb)
+
+y_df_nb <- Reduce(rbind, y_df_nb)
+
+fit3_nb <- fit_ricker_cc(y_df_nb, off_patch = T, fam = "neg_binom")
+fit3_nb_d <- fit_ricker_drop(y_df_nb, off_patch = T, patch_col = "patch", fam = "neg_binom")
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
# Main updates
- Updated likelihood functions (**Poisson and NB**) to work with $\log(\alpha)$ instead of $\alpha$. The working params are back-transformed for reporting, using the Delta method for SEs.
- Checked the "fill-in" functions for EM and DA to ensure they work with multiple, row-bound series.

## Notes
- DA may sometimes throw an error about `missing where TRUE/FALSE needed` from the `step_out()` function. I think I protected against this, but it would be good to wrap in a `try_catch()` during the full simulations to track how often that happens.
- `fit_ricker_drop()` now needs a `patch_col` argument (column name for the patches) when passing in pre-formatted data. This is because, in order to do things *wrong*, we have to split the data up by patch/series again, collapse the gaps, then put back together. Otherwise, we end up with complete cases again.